### PR TITLE
Add post-hoc residual covariance augmentation after SEM hill climbing

### DIFF
--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -605,10 +605,21 @@ class CausalPipe:
                         max_iter=100,
                         estimator=method.params.get("estimator", default_estimator),
                         ordered=ordered,
+                        finalize_with_resid_covariances=method.params.get(
+                            "finalize_with_resid_covariances", False
+                        ),
+                        mi_cutoff=method.params.get("mi_cutoff", 10.0),
+                        sepc_cutoff=method.params.get("sepc_cutoff", 0.10),
+                        max_add=method.params.get("max_add", 5),
+                        delta_stop=method.params.get("delta_stop", 0.003),
+                        whitelist_pairs=method.params.get("whitelist_pairs"),
+                        forbid_pairs=method.params.get("forbid_pairs"),
+                        same_occasion_regex=method.params.get("same_occasion_regex"),
                     )
                     self.causal_effects[method.name] = {
                         "best_graph": best_graph,
                         "summary": sem_results,
+                        "resid_cov_aug": sem_results.get("resid_cov_aug"),
                     }
 
                     print("Saving results to output directory.")

--- a/causal_pipe/sem/resid_covariance_augmentation.py
+++ b/causal_pipe/sem/resid_covariance_augmentation.py
@@ -1,0 +1,311 @@
+"""Utilities for post-hoc residual covariance augmentation in SEM models."""
+
+from typing import Optional, Dict, Any, List
+
+import pandas as pd
+
+
+def augment_residual_covariances_stepwise(
+    data: pd.DataFrame,
+    model_string: str,
+    estimator: str = "MLR",
+    std_lv: bool = True,
+    max_add: int = 5,
+    mi_cutoff: float = 10.0,
+    sepc_cutoff: float = 0.10,
+    delta_stop: float = 0.003,
+    whitelist_pairs: Optional[pd.DataFrame] = None,
+    forbid_pairs: Optional[pd.DataFrame] = None,
+    same_occasion_regex: Optional[str] = None,
+    verbose: bool = True,
+) -> Dict[str, Any]:
+    """Augment residual covariances for a fitted SEM model using a small stepwise search.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Dataset used for fitting the model.
+    model_string : str
+        lavaan model specification.
+    estimator : str, optional
+        lavaan estimator, by default "MLR".
+    std_lv : bool, optional
+        Whether to standardize latent variables, by default True.
+    max_add : int, optional
+        Maximum number of covariances to add, by default 5.
+    mi_cutoff : float, optional
+        Minimum modification index threshold, by default 10.0.
+    sepc_cutoff : float, optional
+        Minimum |sepc.all| threshold, by default 0.10.
+    delta_stop : float, optional
+        Minimum improvement in CFI or RMSEA required to continue, by default 0.003.
+    whitelist_pairs : Optional[pd.DataFrame], optional
+        Optional whitelist of pairs with columns ``lhs`` and ``rhs``.
+    forbid_pairs : Optional[pd.DataFrame], optional
+        Optional blocklist of pairs with columns ``lhs`` and ``rhs``.
+    same_occasion_regex : Optional[str], optional
+        Regex to enforce same occasion pairs, by default None.
+    verbose : bool, optional
+        If True, prints progress information.
+
+    Returns
+    -------
+    Dict[str, Any]
+        A dictionary with the final model string, fit measures, history and added covariances.
+    """
+    import rpy2.robjects as ro
+    from rpy2.robjects import pandas2ri
+    from rpy2.robjects.conversion import localconverter
+    import rpy2.robjects.packages as rpackages
+
+    pandas2ri.activate()
+    if not rpackages.isinstalled("lavaan"):
+        utils = rpackages.importr("utils")
+        utils.install_packages("lavaan")
+    ro.r("library(lavaan)")
+
+    with localconverter(ro.default_converter + pandas2ri.converter):
+        r_data = ro.conversion.py2rpy(data)
+
+    ro.globalenv["data"] = r_data
+    ro.globalenv["model_string"] = model_string
+    ro.globalenv["estimator"] = estimator
+    ro.globalenv["std_lv"] = std_lv
+    ro.globalenv["mi_cutoff"] = mi_cutoff
+    ro.globalenv["sepc_cutoff"] = sepc_cutoff
+    ro.globalenv["delta_stop"] = delta_stop
+    ro.globalenv["max_add"] = max_add
+
+    if whitelist_pairs is not None and len(whitelist_pairs):
+        wl = whitelist_pairs[["lhs", "rhs"]].copy()
+        with localconverter(ro.default_converter + pandas2ri.converter):
+            ro.globalenv["WL"] = ro.conversion.py2rpy(wl)
+    else:
+        ro.globalenv["WL"] = ro.r("NULL")
+    if forbid_pairs is not None and len(forbid_pairs):
+        fb = forbid_pairs[["lhs", "rhs"]].copy()
+        with localconverter(ro.default_converter + pandas2ri.converter):
+            ro.globalenv["FB"] = ro.conversion.py2rpy(fb)
+    else:
+        ro.globalenv["FB"] = ro.r("NULL")
+
+    ro.globalenv["same_regex"] = (
+        same_occasion_regex if same_occasion_regex else ro.r("NA_character_")
+    )
+    ro.globalenv["verbose"] = verbose
+
+    ro.r(
+        """
+get_fit <- function(fit) {
+  fm <- lavInspect(fit, "fit.measures")
+  out <- list(
+    cfi = unname(fm["cfi"]),
+    cfi.scaled = if ("cfi.scaled" %in% names(fm)) unname(fm["cfi.scaled"]) else NA_real_,
+    tli = unname(fm["tli"]),
+    tli.scaled = if ("tli.scaled" %in% names(fm)) unname(fm["tli.scaled"]) else NA_real_,
+    rmsea = unname(fm["rmsea"]),
+    rmsea.scaled = if ("rmsea.scaled" %in% names(fm)) unname(fm["rmsea.scaled"]) else NA_real_,
+    srmr = unname(fm["srmr"]),
+    aic = unname(fm["aic"]),
+    bic = unname(fm["bic"])
+  )
+  return(out)
+}
+
+robust_mi_col <- function(mi_df) {
+  if ("mi.robust" %in% names(mi_df)) return("mi.robust")
+  if ("mi.scaled" %in% names(mi_df)) return("mi.scaled")
+  return("mi")
+}
+
+same_occasion_ok <- function(lhs, rhs, rx) {
+  if (is.na(rx) || is.null(rx)) return(TRUE)
+  ml <- regexec(rx, lhs); mr <- regexec(rx, rhs)
+  sl <- regmatches(lhs, ml)[[1]]; sr <- regmatches(rhs, mr)[[1]]
+  if (length(sl) < 3 || length(sr) < 3) return(FALSE)
+  return(tail(sl,1) == tail(sr,1))
+}
+
+accept_pair <- function(lhs, rhs, WL, FB) {
+  if (!is.null(FB)) {
+    if (nrow(subset(FB, (lhs==.data$lhs & rhs==.data$rhs) | (lhs==.data$rhs & rhs==.data$lhs)))>0) return(FALSE)
+  }
+  if (!is.null(WL)) {
+    return(nrow(subset(WL, (lhs==.data$lhs & rhs==.data$rhs) | (lhs==.data$rhs & rhs==.data$lhs)))>0)
+  }
+  return(TRUE)
+}
+
+model_cur <- model_string
+fit <- sem(model_cur, data=data, std.lv=std_lv, estimator=estimator)
+fit_init <- get_fit(fit)
+fit_hist <- list(fit_init)
+added <- list()
+
+for (k in seq_len(max_add)) {
+  mi <- modindices(fit)
+  mi <- mi[mi$op=="~~" & mi$lhs != mi$rhs,, drop=FALSE]
+
+  PT <- parTable(fit)
+  have <- PT[PT$op=="~~" & PT$free>0, c("lhs","rhs")]
+  if (nrow(have)>0L) {
+    keep_idx <- rep(TRUE, nrow(mi))
+    for (i in seq_len(nrow(mi))) {
+      lhs <- mi$lhs[i]; rhs <- mi$rhs[i]
+      if (nrow(subset(have, (lhs==.data$lhs & rhs==.data$rhs) | (lhs==.data$rhs & rhs==.data$lhs)))>0) keep_idx[i] <- FALSE
+    }
+    mi <- mi[keep_idx,,drop=FALSE]
+  }
+
+  dir <- PT[PT$op=="~" & PT$free>0, c("lhs","rhs")]
+  if (nrow(dir)>0L && nrow(mi)>0L) {
+    keep_idx <- rep(TRUE, nrow(mi))
+    for (i in seq_len(nrow(mi))) {
+      lhs <- mi$lhs[i]; rhs <- mi$rhs[i]
+      if (nrow(subset(dir, (lhs==.data$lhs & rhs==.data$rhs) | (lhs==.data$rhs & rhs==.data$lhs)))>0) keep_idx[i] <- FALSE
+    }
+    mi <- mi[keep_idx,,drop=FALSE]
+  }
+
+  if (nrow(mi)>0L) {
+    keep_idx <- rep(TRUE, nrow(mi))
+    for (i in seq_len(nrow(mi))) {
+      if (!accept_pair(mi$lhs[i], mi$rhs[i], WL, FB)) keep_idx[i] <- FALSE
+      if (!same_occasion_ok(mi$lhs[i], mi$rhs[i], same_regex)) keep_idx[i] <- FALSE
+    }
+    mi <- mi[keep_idx,,drop=FALSE]
+  }
+
+  if (nrow(mi)==0L) break
+
+  mi_col <- robust_mi_col(mi)
+  mi <- mi[!is.na(mi[[mi_col]]) & mi[[mi_col]] >= mi_cutoff & !is.na(mi$sepc.all) & abs(mi$sepc.all) >= sepc_cutoff,, drop=FALSE]
+  if (nrow(mi)==0L) break
+
+  o <- order(-mi[[mi_col]], -abs(mi$sepc.all))
+  cand <- mi[o[1],,, drop=FALSE]
+  add_line <- paste0(cand$lhs, " ~~ ", cand$rhs)
+  model_try <- paste(model_cur, add_line, sep="\n")
+
+  fit_new <- try(suppressWarnings(sem(model_try, data=data, std.lv=std_lv, estimator=estimator)), silent=TRUE)
+  if (inherits(fit_new, "try-error")) break
+
+  fit_old <- fit_init
+  fit_new_m <- get_fit(fit_new)
+
+  cfi_old <- if (!is.na(fit_old$cfi.scaled)) fit_old$cfi.scaled else fit_old$cfi
+  cfi_new <- if (!is.na(fit_new_m$cfi.scaled)) fit_new_m$cfi.scaled else fit_new_m$cfi
+  rmsea_old <- if (!is.na(fit_old$rmsea.scaled)) fit_old$rmsea.scaled else fit_old$rmsea
+  rmsea_new <- if (!is.na(fit_new_m$rmsea.scaled)) fit_new_m$rmsea.scaled else fit_new_m$rmsea
+
+  d_cfi <- cfi_new - cfi_old
+  d_rmsea <- rmsea_old - rmsea_new
+
+  pe <- parameterEstimates(fit_new, standardized=TRUE)
+  heywood <- any(pe$op=="~~" & pe$lhs==pe$rhs & pe$std.all < 0, na.rm=TRUE)
+
+  if (heywood || (d_cfi < delta_stop && d_rmsea < delta_stop && (is.na(fit_old$bic) || is.na(fit_new_m$bic) || (fit_new_m$bic - fit_old$bic) >= -2))) {
+    break
+  } else {
+    model_cur <- model_try
+    fit <- fit_new
+    fit_init <- fit_new_m
+    added[[length(added)+1]] <- list(lhs=cand$lhs, rhs=cand$rhs, mi=cand[[mi_col]], sepc=cand$sepc.all, mi_col=mi_col, step=length(added)+1)
+    fit_hist[[length(fit_hist)+1]] <- fit_new_m
+    if (verbose) cat(paste0("Added ", add_line, "\n"))
+  }
+}
+
+final_fit <- fit_init
+"""
+    )
+
+    fit_measures = dict(
+        zip(
+            [
+                "cfi",
+                "cfi.scaled",
+                "tli",
+                "tli.scaled",
+                "rmsea",
+                "rmsea.scaled",
+                "srmr",
+                "aic",
+                "bic",
+            ],
+            [float(x) if x is not ro.NA_Logical else None for x in ro.r("unlist(final_fit)")],
+        )
+    )
+
+    initial_fit_measures = dict(
+        zip(
+            [
+                "cfi",
+                "cfi.scaled",
+                "tli",
+                "tli.scaled",
+                "rmsea",
+                "rmsea.scaled",
+                "srmr",
+                "aic",
+                "bic",
+            ],
+            [
+                float(x) if x is not ro.NA_Logical else None
+                for x in ro.r("unlist(fit_hist[[1]])")
+            ],
+        )
+    )
+
+    hist_list: List[Dict[str, float]] = []
+    n_hist = int(ro.r("length(fit_hist)")[0])
+    for i in range(n_hist):
+        vals = list(ro.r(f"unlist(fit_hist[[{i+1}]])"))
+        hist_list.append(
+            dict(
+                zip(
+                    [
+                        "cfi",
+                        "cfi.scaled",
+                        "tli",
+                        "tli.scaled",
+                        "rmsea",
+                        "rmsea.scaled",
+                        "srmr",
+                        "aic",
+                        "bic",
+                    ],
+                    [float(x) if x is not ro.NA_Logical else None for x in vals],
+                )
+            )
+        )
+
+    added_list: List[Dict[str, Any]] = []
+    n_added = int(ro.r("length(added)")[0])
+    for i in range(n_added):
+        lhs = str(ro.r(f"added[[{i+1}]]$lhs")[0])
+        rhs = str(ro.r(f"added[[{i+1}]]$rhs")[0])
+        mi = float(ro.r(f"added[[{i+1}]]$mi")[0])
+        sepc = float(ro.r(f"added[[{i+1}]]$sepc")[0])
+        mi_col = str(ro.r(f"added[[{i+1}]]$mi_col")[0])
+        step = int(ro.r(f"added[[{i+1}]]$step")[0])
+        added_list.append(
+            {
+                "lhs": lhs,
+                "rhs": rhs,
+                "mi": mi,
+                "sepc.all": sepc,
+                "mi_col": mi_col,
+                "step": step,
+            }
+        )
+
+    final_model_string = str(ro.r("model_cur")[0])
+
+    return {
+        "final_model_string": final_model_string,
+        "fit_measures": fit_measures,
+        "initial_fit_measures": initial_fit_measures,
+        "added_covariances": added_list,
+        "fit_history": hist_list,
+    }

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -452,6 +452,14 @@ search_best_graph_climber(
     node_names: Optional[List[str]] = None,
     max_iter: int = 1000,
     estimator: str = "MLM",
+    finalize_with_resid_covariances: bool = False,
+    mi_cutoff: float = 10.0,
+    sepc_cutoff: float = 0.10,
+    max_add: int = 5,
+    delta_stop: float = 0.003,
+    whitelist_pairs: Optional[pd.DataFrame] = None,
+    forbid_pairs: Optional[pd.DataFrame] = None,
+    same_occasion_regex: Optional[str] = None,
     **kwargs,
 ) -> Tuple[GeneralGraph, Dict[str, Any]]
 ```
@@ -462,12 +470,23 @@ search_best_graph_climber(
     - `node_names` (`Optional[List[str]]`, default `None`): A list of variable names in the dataset.
     - `max_iter` (`int`, default `1000`): The maximum number of iterations for the hill-climbing search.
     - `estimator` (`str`, default `"MLM"`): The estimator to use for fitting the SEM model. Options include `"MLM"`, `"MLR"`, `"ULS"`, `"WLSMV"`.
+    - `finalize_with_resid_covariances` (`bool`, default `False`): If `True`, run a post-hoc stepwise residual covariance augmentation.
+    - `mi_cutoff` (`float`, default `10.0`): Minimum modification index threshold for considering a covariance.
+    - `sepc_cutoff` (`float`, default `0.10`): Minimum absolute `sepc.all` threshold.
+    - `max_add` (`int`, default `5`): Maximum number of covariances to add.
+    - `delta_stop` (`float`, default `0.003`): Minimum improvement required in fit indices to continue.
+    - `whitelist_pairs` (`Optional[pd.DataFrame]`, default `None`): Optional whitelist of pairs (`lhs`, `rhs`).
+    - `forbid_pairs` (`Optional[pd.DataFrame]`, default `None`): Optional blocklist of pairs.
+    - `same_occasion_regex` (`Optional[str]`, default `None`): Regex enforcing same-occasion pairs unless whitelisted.
     - `**kwargs`: Additional keyword arguments.
 
 - **Returns:**
     - `Tuple[GeneralGraph, Dict[str, Any]]`: A tuple containing:
         - `best_graph` (`GeneralGraph`): The graph structure with the best SEM fit.
-        - `best_score` (`Dict[str, Any]`): The SEM fitting results for the best graph.
+        - `best_score` (`Dict[str, Any]`): SEM results. When residual covariance
+          augmentation is enabled, this dictionary also includes
+          `without_added_covariance_score` (the pre-augmentation score) and
+          `resid_cov_aug` (details of the augmentation step).
 
 - **Usage Example:**
 
@@ -482,9 +501,10 @@ search_best_graph_climber(
       data=data,
       initial_graph=initial_graph,
       max_iter=500,
-      estimator="MLR"
+      estimator="MLR",
+      finalize_with_resid_covariances=True,
   )
-  
+
   print(best_graph)
   print(best_score["fit_measures"])
   ```

--- a/examples/example_added_covariance.py
+++ b/examples/example_added_covariance.py
@@ -1,0 +1,94 @@
+import numpy as np
+import pandas as pd
+
+from causal_pipe.causal_pipe import (
+    CausalPipe,
+    CausalPipeConfig,
+    FASSkeletonMethod,
+    FCIOrientationMethod,
+)
+from causal_pipe.pipe_config import (
+    VariableTypes,
+    DataPreprocessingParams,
+    CausalEffectMethod,
+)
+
+
+def simulate_data(n_samples: int = 500, seed: int = 0) -> pd.DataFrame:
+    """Simulate dataset with a residual covariance between Var0 and Ord3."""
+    rng = np.random.default_rng(seed)
+
+    # Var0 and Ord3 share unmeasured influence (correlated residuals)
+    cov = 0.5
+    var0, ord3_cont = rng.multivariate_normal(
+        [0.0, 0.0], [[1.0, cov], [cov, 1.0]], size=n_samples
+    ).T
+
+    # Other variables following the easy_ordinal example
+    var1_cont = rng.normal(size=n_samples) + var0 * 3
+    var2_cont = rng.normal(size=n_samples) + var0
+
+    ord1 = pd.cut(var1_cont, bins=3, labels=["Low", "Medium", "High"], include_lowest=True).codes
+    ord2 = pd.cut(var2_cont, bins=3, labels=["Low", "Medium", "High"], include_lowest=True).codes
+    ord3 = pd.cut(ord3_cont, bins=3, labels=["Low", "Medium", "High"], include_lowest=True).codes
+
+    var3 = -2 * ord1 + rng.normal(size=n_samples)
+    var4 = 0.5 * ord2 + ord3 + rng.normal(size=n_samples)
+    var5 = var3 + var4 + rng.normal(size=n_samples)
+    var6 = rng.normal(size=n_samples)
+
+    return pd.DataFrame(
+        {
+            "Var0": var0,
+            "Ord1": ord1,
+            "Ord2": ord2,
+            "Ord3": ord3,
+            "Var3": var3,
+            "Var4": var4,
+            "Var5": var5,
+            "Var6": var6,
+        }
+    )
+
+
+def run_pipeline_with_resid_covariance():
+    data = simulate_data()
+
+    config = CausalPipeConfig(
+        variable_types=VariableTypes(
+            continuous=["Var0", "Var3", "Var4", "Var5", "Var6"],
+            ordinal=["Ord1", "Ord2", "Ord3"],
+        ),
+        preprocessing_params=DataPreprocessingParams(),
+        skeleton_method=FASSkeletonMethod(),
+        orientation_method=FCIOrientationMethod(),
+        causal_effect_methods=[
+            CausalEffectMethod(
+                name="sem-climbing",
+                directed=True,
+                params={
+                    "estimator": "MLR",
+                    "finalize_with_resid_covariances": True,
+                    "whitelist_pairs": pd.DataFrame({"lhs": ["Var0"], "rhs": ["Ord3"]}),
+                    "max_add": 1,
+                },
+            )
+        ],
+        study_name="example_added_covariance",
+        output_path="./output/",
+        show_plots=False,
+        verbose=True,
+    )
+
+    pipe = CausalPipe(config)
+    pipe.run_pipeline(data)
+
+    aug = pipe.causal_effects["sem-climbing"].get("resid_cov_aug")
+    print("Added covariances:", aug["added_covariances"])
+    print("Initial fit:", aug["initial_fit_measures"])
+    print("Final fit:", aug["fit_measures"])
+    print("Final model string:\n", aug["final_model_string"])
+
+
+if __name__ == "__main__":
+    run_pipeline_with_resid_covariance()


### PR DESCRIPTION
## Summary
- add `augment_residual_covariances_stepwise` helper for stepwise MI-based residual covariance fitting via lavaan
- allow `search_best_graph_climber` to optionally run this augmentation and expose results
- wire the new option through `causal_pipe` and document the updated API
- provide `examples/example_added_covariance.py` demonstrating post-hoc residual covariance augmentation on simulated correlated residuals using `CausalPipeConfig`

## Testing
- `python -m py_compile examples/example_added_covariance.py causal_pipe/sem/resid_covariance_augmentation.py causal_pipe/sem/sem.py causal_pipe/causal_pipe.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b454fdf7f083309378a8e87f65cd33