### PR TITLE
Handle missing same_occasion_regex in SEM augmentation

### DIFF
--- a/causal_pipe/sem/resid_covariance_augmentation.py
+++ b/causal_pipe/sem/resid_covariance_augmentation.py
@@ -89,9 +89,10 @@ def augment_residual_covariances_stepwise(
     else:
         ro.globalenv["FB"] = ro.r("NULL")
 
-    ro.globalenv["same_regex"] = (
-        same_occasion_regex if same_occasion_regex else ro.r("NA_character_")
-    )
+    if isinstance(same_occasion_regex, str) and same_occasion_regex:
+        ro.globalenv["same_regex"] = same_occasion_regex
+    else:
+        ro.globalenv["same_regex"] = ro.r("NA_character_")
     ro.globalenv["verbose"] = verbose
 
     ro.r(


### PR DESCRIPTION
## Summary
- Avoid rpy2 conversion errors when `same_occasion_regex` is missing or not a string

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b45f251e4883309c83fa3c1823d818