### PR TITLE
Fix lavaan std.lv argument in SEM residual covariance augmentation

### DIFF
--- a/causal_pipe/sem/resid_covariance_augmentation.py
+++ b/causal_pipe/sem/resid_covariance_augmentation.py
@@ -132,7 +132,7 @@ def augment_residual_covariances_stepwise(
         return True
 
     model_cur = model_string
-    fit = sem(model_cur, data=r_data, std_lv=std_lv, estimator=estimator)
+    fit = sem(model_cur, data=r_data, estimator=estimator, **{"std.lv": std_lv})
     fit_init = get_fit(fit)
     fit_hist: List[Dict[str, Optional[float]]] = [fit_init]
     added: List[Dict[str, Any]] = []
@@ -197,7 +197,7 @@ def augment_residual_covariances_stepwise(
         model_try = model_cur + "\n" + add_line
 
         try:
-            fit_new = sem(model_try, data=r_data, std_lv=std_lv, estimator=estimator)
+            fit_new = sem(model_try, data=r_data, estimator=estimator, **{"std.lv": std_lv})
         except Exception:
             break
 


### PR DESCRIPTION
## Summary
- Ensure residual covariance augmentation passes lavaan's `std.lv` parameter correctly by using `**{"std.lv": std_lv}`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b467c1fe2c83308dd552629c2651ad