### PR TITLE
Fix SEM coefficient graph edges to match fitted model

### DIFF
--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -557,17 +557,14 @@ class CausalPipe:
                         ordered=ordered,
                         exogenous_vars_model_1=exogenous_vars,
                     )
-                    coef_graph, edges_with_coefficients = (
-                        add_edge_coefficients_from_sem_fit(
-                            directed_graph,
-                            model_output=self.causal_effects[method.name],
-                        )
+                    coef_graph, _ = add_edge_coefficients_from_sem_fit(
+                        directed_graph,
+                        model_output=self.causal_effects[method.name],
                     )
                     out_sem_dir = os.path.join(self.output_path, "causal_effect", "sem")
                     os.makedirs(out_sem_dir, exist_ok=True)
                     visualize_graph(
                         coef_graph,
-                        edges=edges_with_coefficients,
                         title="SEM Result",
                         labels=dict(zip(range(len(df.columns)), df.columns)),
                         show=show_plot,
@@ -637,16 +634,13 @@ class CausalPipe:
                         show=show_plot,
                         output_path=os.path.join(out_sem_dir, "best_graph.png"),
                     )
-                    coef_graph, edges_with_coefficients = (
-                        add_edge_coefficients_from_sem_fit(
-                            best_graph,
-                            model_output=self.causal_effects[method.name]["summary"],
-                        )
+                    coef_graph, _ = add_edge_coefficients_from_sem_fit(
+                        best_graph,
+                        model_output=self.causal_effects[method.name]["summary"],
                     )
                     visualize_graph(
                         coef_graph,
                         title="Best Graph Climber Result With Coefficients",
-                        edges=edges_with_coefficients,
                         labels=dict(zip(range(len(df.columns)), df.columns)),
                         show=show_plot,
                         output_path=os.path.join(


### PR DESCRIPTION
## Summary
- Rebuild graphs from SEM fits and attach coefficients so structure mirrors the fit summary
- Visualize all edges when plotting SEM results to avoid dropping edges without coefficients
- Tolerate multiple coefficient column names when attaching measurement, structural, and residual parameters

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b6195008d083308f2d1404a4c02470