### PR TITLE
feat: add FCI bootstrapping options

### DIFF
--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -436,7 +436,7 @@ class CausalPipe:
                 )
                 self.directed_graph = graph_fci
 
-                if self.skeleton_method.fci_bootstrap_resamples > 0:
+                if self.orientation_method.fci_bootstrap_resamples > 0:
                     fci_kwargs = dict(
                         alpha=self.orientation_method.alpha,
                         knowledge=self.orientation_method.background_knowledge,
@@ -445,8 +445,8 @@ class CausalPipe:
                     )
                     self.fci_edge_orientation_probabilities = bootstrap_fci_edge_stability(
                         df,
-                        resamples=self.skeleton_method.fci_bootstrap_resamples,
-                        random_state=self.skeleton_method.fci_bootstrap_random_state,
+                        resamples=self.orientation_method.fci_bootstrap_resamples,
+                        random_state=self.orientation_method.fci_bootstrap_random_state,
                         fci_kwargs=fci_kwargs,
                         output_dir=os.path.join(
                             self.output_path, "fci_bootstrap"

--- a/causal_pipe/pipe_config.py
+++ b/causal_pipe/pipe_config.py
@@ -141,8 +141,6 @@ class SkeletonMethod(BaseModel):
     )
     alpha: float = 0.05
     params: Optional[Dict[str, Any]] = Field(default_factory=dict)
-    fci_bootstrap_resamples: int = 0
-    fci_bootstrap_random_state: Optional[int] = None
 
     @field_validator("alpha")
     @classmethod
@@ -151,12 +149,6 @@ class SkeletonMethod(BaseModel):
             raise ValueError("alpha must be between 0.0 and 1.0")
         return v
 
-    @field_validator("fci_bootstrap_resamples")
-    @classmethod
-    def check_fci_bootstrap_resamples(cls, v):
-        if v < 0:
-            raise ValueError("fci_bootstrap_resamples must be non-negative")
-        return v
 
     class Config:
         validate_assignment = True
@@ -241,6 +233,8 @@ class FCIOrientationMethod(OrientationMethod):
     background_knowledge: Optional[BackgroundKnowledge] = None
     alpha: float = 0.05
     max_path_length: int = 3
+    fci_bootstrap_resamples: int = 0
+    fci_bootstrap_random_state: Optional[int] = None
 
     @field_validator("alpha")
     @classmethod
@@ -254,6 +248,13 @@ class FCIOrientationMethod(OrientationMethod):
     def check_max_path_length(cls, v):
         if v < 0:
             raise ValueError("max_path_length must be non-negative")
+        return v
+
+    @field_validator("fci_bootstrap_resamples")
+    @classmethod
+    def check_fci_bootstrap_resamples(cls, v):
+        if v < 0:
+            raise ValueError("fci_bootstrap_resamples must be non-negative")
         return v
 
     class Config:

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -196,12 +196,9 @@ Retrieves the names of ordinal and nominal variables.
         - `"mv_fisherz"`
     - `alpha` (`float`, default `0.05`): Significance level for tests. Must be between `0.0` and `1.0`.
     - `params` (`Optional[Dict[str, Any]]`, default `{}`): Additional parameters.
-    - `fci_bootstrap_resamples` (`int`, default `0`): If greater than `0`, run FCI on that many bootstrap samples to estimate edge orientation stability. The three most frequent bootstrapped graphs are saved under `fci_bootstrap/`.
-    - `fci_bootstrap_random_state` (`Optional[int]`, default `None`): Seed for the FCI bootstrap resampling procedure.
 
 - **Validations:**
     - `alpha` must be between `0.0` and `1.0`.
-    - `fci_bootstrap_resamples` must be non-negative.
 
 ---
 
@@ -281,10 +278,13 @@ Retrieves the names of ordinal and nominal variables.
     - `background_knowledge` (`Optional[BackgroundKnowledge]`, default `None`): Background knowledge for FCI.
     - `alpha` (`float`, default `0.05`): Significance level for tests. Must be between `0.0` and `1.0`.
     - `max_path_length` (`int`, default `3`): Maximum path length for FCI. Must be non-negative.
+    - `fci_bootstrap_resamples` (`int`, default `0`): If greater than `0`, run FCI on that many bootstrap samples to estimate edge orientation stability. The three most frequent bootstrapped graphs are saved under `fci_bootstrap/`.
+    - `fci_bootstrap_random_state` (`Optional[int]`, default `None`): Seed for the FCI bootstrap resampling procedure.
 
 - **Validations:**
     - `alpha` must be between `0.0` and `1.0`.
     - `max_path_length` must be non-negative.
+    - `fci_bootstrap_resamples` must be non-negative.
 
 - **Configuration:**
     - `arbitrary_types_allowed = True` (Allows non-Pydantic types like `BackgroundKnowledge`)
@@ -783,6 +783,8 @@ class FCIOrientationMethod(OrientationMethod):
     background_knowledge: Optional[BackgroundKnowledge] = None
     alpha: float = 0.05
     max_path_length: int = 3
+    fci_bootstrap_resamples: int = 0
+    fci_bootstrap_random_state: Optional[int] = None
 
     # Validation for alpha
     @field_validator("alpha")
@@ -798,6 +800,13 @@ class FCIOrientationMethod(OrientationMethod):
     def check_max_path_length(cls, v):
         if v < 0:
             raise ValueError("max_path_length must be non-negative")
+        return v
+
+    @field_validator("fci_bootstrap_resamples")
+    @classmethod
+    def check_fci_bootstrap_resamples(cls, v):
+        if v < 0:
+            raise ValueError("fci_bootstrap_resamples must be non-negative")
         return v
 
     class Config:


### PR DESCRIPTION
## Summary
- allow configuring FCI bootstrapping via `FCIOrientationMethod`
- use the new parameters when bootstrapping FCI edge orientation
- document FCI bootstrapping fields in the API reference

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b914aad43c8330a84d17420c3f519c