### PR TITLE
Add FAS skeleton bootstrapping and generalize orientation bootstrap

### DIFF
--- a/causal_pipe/pipe_config.py
+++ b/causal_pipe/pipe_config.py
@@ -141,12 +141,21 @@ class SkeletonMethod(BaseModel):
     )
     alpha: float = 0.05
     params: Optional[Dict[str, Any]] = Field(default_factory=dict)
+    bootstrap_resamples: int = 0
+    bootstrap_random_state: Optional[int] = None
 
     @field_validator("alpha")
     @classmethod
     def check_alpha(cls, v):
         if not (0.0 < v < 1.0):
             raise ValueError("alpha must be between 0.0 and 1.0")
+        return v
+
+    @field_validator("bootstrap_resamples")
+    @classmethod
+    def check_bootstrap_resamples(cls, v):
+        if v < 0:
+            raise ValueError("bootstrap_resamples must be non-negative")
         return v
 
 
@@ -219,9 +228,18 @@ class OrientationMethod(BaseModel):
     conditional_independence_method: ConditionalIndependenceMethodEnum = (
         ConditionalIndependenceMethodEnum.FISHERZ
     )
+    bootstrap_resamples: int = 0
+    bootstrap_random_state: Optional[int] = None
 
     class Config:
         validate_assignment = True
+
+    @field_validator("bootstrap_resamples")
+    @classmethod
+    def check_bootstrap_resamples(cls, v):
+        if v < 0:
+            raise ValueError("bootstrap_resamples must be non-negative")
+        return v
 
 
 class FCIOrientationMethod(OrientationMethod):
@@ -233,8 +251,6 @@ class FCIOrientationMethod(OrientationMethod):
     background_knowledge: Optional[BackgroundKnowledge] = None
     alpha: float = 0.05
     max_path_length: int = 3
-    fci_bootstrap_resamples: int = 0
-    fci_bootstrap_random_state: Optional[int] = None
 
     @field_validator("alpha")
     @classmethod
@@ -248,13 +264,6 @@ class FCIOrientationMethod(OrientationMethod):
     def check_max_path_length(cls, v):
         if v < 0:
             raise ValueError("max_path_length must be non-negative")
-        return v
-
-    @field_validator("fci_bootstrap_resamples")
-    @classmethod
-    def check_fci_bootstrap_resamples(cls, v):
-        if v < 0:
-            raise ValueError("fci_bootstrap_resamples must be non-negative")
         return v
 
     class Config:

--- a/tests/test_bootstrap_edge_stability.py
+++ b/tests/test_bootstrap_edge_stability.py
@@ -12,6 +12,7 @@ sys.modules.setdefault("causal_pipe", causal_pipe_pkg)
 
 from causal_pipe.sem.sem import (
     bootstrap_fci_edge_stability,
+    bootstrap_fas_edge_stability,
     search_best_graph_climber,
 )
 from causallearn.search.ConstraintBased.FCI import fci
@@ -33,6 +34,22 @@ def test_bootstrap_fci_edge_stability_returns_probabilities():
     assert all(isinstance(v, dict) for v in probs.values())
     for orient_probs in probs.values():
         assert all(0.0 <= p <= 1.0 for p in orient_probs.values())
+    assert best_graph is None or isinstance(best_graph, tuple)
+
+
+def test_bootstrap_fas_edge_stability_returns_probabilities():
+    np.random.seed(0)
+    n = 100
+    a = np.random.randn(n)
+    b = a + np.random.randn(n) * 0.1
+    c = b + np.random.randn(n) * 0.1
+    data = pd.DataFrame({"A": a, "B": b, "C": c})
+
+    probs, best_graph = bootstrap_fas_edge_stability(
+        data, resamples=2, random_state=1
+    )
+    assert isinstance(probs, dict)
+    assert all(0.0 <= p <= 1.0 for p in probs.values())
     assert best_graph is None or isinstance(best_graph, tuple)
 
 
@@ -121,6 +138,72 @@ def test_fci_bootstrap_saves_graph_with_highest_edge_probability_product(monkeyp
     monkeypatch.setattr("causal_pipe.sem.sem.visualize_graph", viz_mock)
 
     bootstrap_fci_edge_stability(
+        data, resamples=3, random_state=0, output_dir=str(tmp_path)
+    )
+
+    assert len(captured) == 2
+    first_graph, first_title = captured[0]
+    second_graph, second_title = captured[1]
+
+    assert len(first_graph.get_graph_edges()) == 1
+    assert "p=1.00" in first_title
+    assert len(second_graph.get_graph_edges()) == 2
+    assert "p=0.67" in second_title
+
+
+def test_fas_bootstrap_saves_graph_with_highest_edge_probability_product(monkeypatch, tmp_path):
+    data = pd.DataFrame({"A": [0, 1, 2], "B": [0, 1, 2], "C": [0, 1, 2]})
+
+    class MockNode:
+        def __init__(self, name):
+            self._name = name
+
+        def get_name(self):
+            return self._name
+
+    class MockEdge:
+        def __init__(self, n1, n2):
+            self._n1 = n1
+            self._n2 = n2
+
+        def get_node1(self):
+            return self._n1
+
+        def get_node2(self):
+            return self._n2
+
+    class MockGraph:
+        def __init__(self, edges):
+            self._edges = edges
+
+        def get_graph_edges(self):
+            return self._edges
+
+    A, B, C = MockNode("A"), MockNode("B"), MockNode("C")
+    g1 = MockGraph([MockEdge(A, B)])
+    g2 = MockGraph([MockEdge(A, B), MockEdge(B, C)])
+
+    graphs = iter([g2, g2, g1])
+
+    def fas_mock(*args, **kwargs):
+        return next(graphs), None, None
+
+    monkeypatch.setattr("causal_pipe.sem.sem.fas", fas_mock)
+
+    class DummyCIT:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr("causal_pipe.sem.sem.CIT", DummyCIT)
+
+    captured = []
+
+    def viz_mock(graph_obj, title, show, output_path):
+        captured.append((graph_obj, title))
+
+    monkeypatch.setattr("causal_pipe.sem.sem.visualize_graph", viz_mock)
+
+    bootstrap_fas_edge_stability(
         data, resamples=3, random_state=0, output_dir=str(tmp_path)
     )
 


### PR DESCRIPTION
## Summary
- add `bootstrap_fas_edge_stability` to estimate edge presence probabilities and select top graphs
- parameterize skeleton methods with `bootstrap_resamples`/`bootstrap_random_state` and integrate FAS bootstrapping in pipeline
- move orientation bootstrapping fields to `OrientationMethod` for reuse

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bae90ae120833083729d87539b1fb2