### PR TITLE
Rename hill climb bootstrap parameters

### DIFF
--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -710,9 +710,9 @@ class CausalPipe:
                         forbid_pairs=method.params.get("forbid_pairs"),
                         same_occasion_regex=method.params.get("same_occasion_regex"),
                         respect_pag=respect_pag,
-                        hc_bootstrap_resamples=method.params.get("hc_bootstrap_resamples"),
-                        hc_bootstrap_random_state=method.params.get(
-                            "hc_bootstrap_random_state"
+                        bootstrap_resamples=method.params.get("bootstrap_resamples"),
+                        bootstrap_random_state=method.params.get(
+                            "bootstrap_random_state"
                         ),
                     )
                     self.causal_effects[method.name] = {

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -327,8 +327,8 @@ Retrieves the names of ordinal and nominal variables.
         - `'sem-climbing'`: Structural Equation Modeling with Hill Climbing search of the best graph.
     - `directed` (`bool`, default `True`): Indicates if the method uses a directed graph.
     - `params` (`Optional[Dict[str, Any]]`, default `{}`): Additional parameters for the method.
-    - `hc_bootstrap_resamples` (`int`, default `0`): Number of bootstrap resamples for SEM hill climbing to estimate edge orientation stability. When greater than `0`, the three bootstrapped graphs with the highest product of edge orientation probabilities are saved under `sem_hc_bootstrap/`.
-    - `hc_bootstrap_random_state` (`Optional[int]`, default `None`): Seed for the SEM hill-climb bootstrap procedure.
+    - `bootstrap_resamples` (`int`, default `0`): Number of bootstrap resamples for SEM hill climbing to estimate edge orientation stability. When greater than `0`, the three bootstrapped graphs with the highest product of edge orientation probabilities are saved under `sem_hc_bootstrap/`.
+    - `bootstrap_random_state` (`Optional[int]`, default `None`): Seed for the SEM hill-climb bootstrap procedure.
 
 ---
 
@@ -469,8 +469,8 @@ search_best_graph_climber(
     same_occasion_regex: Optional[str] = None,
     *,
     respect_pag: bool = False,
-    hc_bootstrap_resamples: int = 0,
-    hc_bootstrap_random_state: Optional[int] = None,
+    bootstrap_resamples: int = 0,
+    bootstrap_random_state: Optional[int] = None,
     **kwargs,
 ) -> Tuple[GeneralGraph, Dict[str, Any]]
 ```
@@ -490,8 +490,8 @@ search_best_graph_climber(
     - `forbid_pairs` (`Optional[pd.DataFrame]`, default `None`): Optional blocklist of pairs.
     - `same_occasion_regex` (`Optional[str]`, default `None`): Regex enforcing same-occasion pairs unless whitelisted.
     - `respect_pag` (`bool`, default `False`): When `True`, the search preserves PAG marks (no change to ↔, →, —; only resolves circle endpoints consistent with PAG semantics).
-    - `hc_bootstrap_resamples` (`int`, default `0`): If greater than `0`, run the SEM hill climber on bootstrap resamples to estimate orientation probabilities after hill climbing. The three bootstrapped graphs with the highest product of edge orientation probabilities are stored in `sem_hc_bootstrap/`.
-    - `hc_bootstrap_random_state` (`Optional[int]`, default `None`): Seed for the hill-climb bootstrap resampling procedure.
+    - `bootstrap_resamples` (`int`, default `0`): If greater than `0`, run the SEM hill climber on bootstrap resamples to estimate orientation probabilities after hill climbing. The three bootstrapped graphs with the highest product of edge orientation probabilities are stored in `sem_hc_bootstrap/`.
+    - `bootstrap_random_state` (`Optional[int]`, default `None`): Seed for the hill-climb bootstrap resampling procedure.
     - `**kwargs`: Additional keyword arguments.
 
 - **Returns:**

--- a/examples/easy_ordinal.py
+++ b/examples/easy_ordinal.py
@@ -103,7 +103,7 @@ def compare_easy_dataset_with_ordinal(config: CausalPipeConfig) -> None:
     config.causal_effect_methods = [
         # For ordinal data
         CausalEffectMethod(name="sem", directed=True),
-        CausalEffectMethod(name="sem-climbing", directed=True, params={"estimator": "ML", "respect_pag": True, "hc_bootstrap_resamples": 2, "hc_bootstrap_random_state": 42}),
+        CausalEffectMethod(name="sem-climbing", directed=True, params={"estimator": "ML", "respect_pag": True, "bootstrap_resamples": 2, "bootstrap_random_state": 42}),
     ]
     config.preprocessing_params.keep_only_correlated_with = ["Var0", "Var5"]
     config.preprocessing_params.filter_method = "spearman"

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
             # SEM Climbing, only ML based estimators are supported
             CausalEffectMethod(
                 name="sem-climbing", directed=True, params={"estimator": "ML", "respect_pag": True,
-                                                            "hc_bootstrap_resamples": 2, "hc_bootstrap_random_state": 42}
+                                                            "bootstrap_resamples": 2, "bootstrap_random_state": 42}
 
             ),
             # CausalEffectMethod(

--- a/tests/test_bootstrap_edge_stability.py
+++ b/tests/test_bootstrap_edge_stability.py
@@ -101,8 +101,8 @@ def test_hill_climb_bootstrap_returns_probabilities(monkeypatch):
         data,
         g,
         max_iter=0,
-        hc_bootstrap_resamples=2,
-        hc_bootstrap_random_state=1,
+        bootstrap_resamples=2,
+        bootstrap_random_state=1,
     )
 
     assert "hc_edge_orientation_probabilities" in best_score
@@ -325,8 +325,8 @@ def test_hc_bootstrap_saves_graph_with_highest_edge_probability_product(monkeypa
         data,
         g1,
         max_iter=0,
-        hc_bootstrap_resamples=3,
-        hc_bootstrap_random_state=0,
+        bootstrap_resamples=3,
+        bootstrap_random_state=0,
         hc_bootstrap_output_dir=str(tmp_path),
     )
 


### PR DESCRIPTION
## Summary
- rename `hc_bootstrap_resamples` to `bootstrap_resamples`
- rename `hc_bootstrap_random_state` to `bootstrap_random_state`
- update docs, examples, tests for new parameter names

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bcsl')*

------
https://chatgpt.com/codex/tasks/task_b_68bccc69fb1883308179bf09b7f9978a