### PR TITLE
Add multiprocessing options to bootstrap procedures

### DIFF
--- a/causal_pipe/causal_discovery/bootstrap_utils.py
+++ b/causal_pipe/causal_discovery/bootstrap_utils.py
@@ -1,0 +1,51 @@
+"""Utility helpers for bootstrap-based causal discovery routines."""
+
+from typing import List, Tuple
+
+from causallearn.graph.Edge import Edge
+from causallearn.graph.Endpoint import Endpoint
+from causallearn.graph.GeneralGraph import GeneralGraph
+from causallearn.graph.GraphNode import GraphNode
+
+
+def format_oriented_edge(a: str, b: str, orient: str) -> str:
+    """Return a human-readable string for an oriented edge."""
+    e1, e2 = orient.split("-")
+    if e1 == "TAIL" and e2 == "ARROW":
+        return f"{a} -> {b}"
+    if e1 == "ARROW" and e2 == "TAIL":
+        return f"{a} <- {b}"
+    if e1 == "ARROW" and e2 == "ARROW":
+        return f"{a} <-> {b}"
+    if e1 == "TAIL" and e2 == "TAIL":
+        return f"{a} -- {b}"
+    if e1 == "CIRCLE" and e2 == "ARROW":
+        return f"{a} o-> {b}"
+    if e1 == "ARROW" and e2 == "CIRCLE":
+        return f"{a} <-o {b}"
+    if e1 == "CIRCLE" and e2 == "TAIL":
+        return f"{a} o- {b}"
+    if e1 == "TAIL" and e2 == "CIRCLE":
+        return f"{a} -o {b}"
+    if e1 == "CIRCLE" and e2 == "CIRCLE":
+        return f"{a} o-o {b}"
+    return f"{a} {e1}-{e2} {b}"
+
+
+def make_graph(
+    node_names: List[str],
+    edges_repr: List[Tuple[str, str, str, str]],
+) -> GeneralGraph:
+    """Construct a ``GeneralGraph`` from edge representations."""
+
+    names = set(node_names)
+    for n1, n2, _, _ in edges_repr:
+        names.add(n1)
+        names.add(n2)
+
+    name_to_node = {name: GraphNode(name) for name in names}
+    g = GeneralGraph(list(name_to_node.values()))
+    for n1, n2, e1, e2 in edges_repr:
+        g.add_edge(Edge(name_to_node[n1], name_to_node[n2], Endpoint[e1], Endpoint[e2]))
+    return g
+

--- a/causal_pipe/causal_discovery/fas_bootstrap.py
+++ b/causal_pipe/causal_discovery/fas_bootstrap.py
@@ -1,0 +1,164 @@
+"""Bootstrap edge stability for the FAS algorithm."""
+
+from typing import Dict, Tuple, Optional, List, Any, Set
+import copy
+import os
+import multiprocessing as mp
+import numpy as np
+import pandas as pd
+from causallearn.utils.cit import CIT
+from causallearn.utils.FAS import fas
+from causallearn.graph.GeneralGraph import GeneralGraph
+
+from causal_pipe.utilities.graph_utilities import get_nodes_from_node_names, visualize_graph
+from .bootstrap_utils import make_graph
+
+
+_fas_bootstrap_data = None
+_fas_bootstrap_node_names = None
+_fas_bootstrap_ci_method = None
+_fas_bootstrap_kwargs = None
+_fas_bootstrap_n = None
+
+
+def _init_fas_bootstrap(data, node_names, ci_method, fas_kwargs):
+    """Initializer to share data across FAS bootstrap worker processes."""
+    global _fas_bootstrap_data, _fas_bootstrap_node_names
+    global _fas_bootstrap_ci_method, _fas_bootstrap_kwargs, _fas_bootstrap_n
+    _fas_bootstrap_data = data
+    _fas_bootstrap_node_names = node_names
+    _fas_bootstrap_ci_method = ci_method
+    _fas_bootstrap_kwargs = fas_kwargs
+    _fas_bootstrap_n = data.shape[0]
+
+
+def _fas_bootstrap_worker(seed: int):
+    """Run a single FAS bootstrap iteration."""
+    sample = _fas_bootstrap_data.sample(
+        n=_fas_bootstrap_n, replace=True, random_state=seed
+    )
+    nodes = get_nodes_from_node_names(node_names=_fas_bootstrap_node_names)
+    cit = CIT(data=sample.values, method=_fas_bootstrap_ci_method)
+    g, sepsets, _ = fas(
+        data=sample.values,
+        nodes=nodes,
+        independence_test_method=cit,
+        **_fas_bootstrap_kwargs,
+    )
+
+    edges_repr = []
+    for edge in g.get_graph_edges():
+        n1 = edge.get_node1().get_name()
+        n2 = edge.get_node2().get_name()
+        if n1 <= n2:
+            pair = (n1, n2)
+        else:
+            pair = (n2, n1)
+        edges_repr.append(pair)
+
+    return edges_repr, sepsets
+
+
+def bootstrap_fas_edge_stability(
+    data: pd.DataFrame,
+    resamples: int,
+    *,
+    random_state: Optional[int] = None,
+    fas_kwargs: Optional[Dict[str, Any]] = None,
+    output_dir: Optional[str] = None,
+    n_jobs: Optional[int] = 1,
+) -> Tuple[
+    Dict[Tuple[str, str], float],
+    Optional[
+        Tuple[
+            float,
+            GeneralGraph,
+            Dict[Tuple[str, str], float],
+            Dict[Tuple[int, int], Set[int]],
+        ]
+    ],
+]:
+    """Estimate edge presence probabilities via bootstrapped FAS runs."""
+
+    if resamples <= 0:
+        return {}, None
+
+    rng = np.random.RandomState(random_state)
+    counts: Dict[Tuple[str, str], int] = {}
+    graph_counts: Dict[
+        Tuple[Tuple[str, str], ...], Tuple[int, List[Tuple[str, str]], Dict[Tuple[int, int], Set[int]]]
+    ] = {}
+    fas_kwargs = fas_kwargs or {}
+
+    node_names = list(data.columns)
+    ci_method = fas_kwargs.pop("conditional_independence_method", "fisherz")
+
+    if n_jobs is None or n_jobs <= 0:
+        n_jobs = 1
+    n_jobs = min(n_jobs, resamples)
+
+    seeds = rng.randint(0, 2**32, size=resamples)
+    _init_fas_bootstrap(data, node_names, ci_method, fas_kwargs)
+    if n_jobs == 1:
+        results = [_fas_bootstrap_worker(s) for s in seeds]
+    else:
+        with mp.Pool(
+            processes=n_jobs,
+            initializer=_init_fas_bootstrap,
+            initargs=(data, node_names, ci_method, fas_kwargs),
+        ) as pool:
+            results = pool.map(_fas_bootstrap_worker, seeds)
+
+    for edges_repr, sepsets in results:
+        for pair in edges_repr:
+            counts[pair] = counts.get(pair, 0) + 1
+        key = tuple(sorted(edges_repr))
+        if key in graph_counts:
+            graph_counts[key] = (
+                graph_counts[key][0] + 1,
+                graph_counts[key][1],
+                graph_counts[key][2],
+            )
+        else:
+            graph_counts[key] = (1, list(edges_repr), copy.deepcopy(sepsets))
+
+    probs = {edge: c / resamples for edge, c in counts.items()}
+
+    if probs:
+        print("Edge presence probabilities from FAS bootstrap:")
+        for (a, b), p in probs.items():
+            print(f"  {a} -- {b}: {p:.2f}")
+
+    best_graph_with_bootstrap = None
+    graph_probs: List[Tuple[float, GeneralGraph, Dict[Tuple[int, int], Set[int]]]] = []
+    if graph_counts:
+        for edges_repr, (count, edges_list, seps) in graph_counts.items():
+            prob = count / resamples
+            graph_obj = make_graph(
+                node_names, [(a, b, "TAIL", "TAIL") for a, b in edges_list]
+            )
+            graph_probs.append((prob, graph_obj, seps))
+
+        if graph_probs:
+            best_prob, best_graph, best_sepsets = max(
+                graph_probs, key=lambda x: x[0]
+            )
+            best_graph_with_bootstrap = (
+                best_prob,
+                copy.deepcopy(best_graph),
+                probs,
+                copy.deepcopy(best_sepsets),
+            )
+
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+            top_graphs = sorted(graph_probs, key=lambda x: x[0], reverse=True)[:3]
+            for idx, (prob, graph_obj, _) in enumerate(top_graphs, start=1):
+                title = f"Bootstrap Graph {idx} (p={prob:.2f})"
+                out_path = os.path.join(output_dir, f"graph_{idx}.png")
+                visualize_graph(
+                    graph_obj, title=title, show=False, output_path=out_path
+                )
+
+    return probs, best_graph_with_bootstrap
+

--- a/causal_pipe/causal_discovery/fci_bootstrap.py
+++ b/causal_pipe/causal_discovery/fci_bootstrap.py
@@ -1,0 +1,167 @@
+"""Bootstrap edge orientation stability for the FCI algorithm."""
+
+from typing import Dict, Tuple, Optional, List, Any
+import copy
+import os
+import multiprocessing as mp
+import numpy as np
+import pandas as pd
+from bcsl.fci import fci_orient_edges_from_graph_node_sepsets
+from causallearn.graph.GeneralGraph import GeneralGraph
+
+from causal_pipe.utilities.graph_utilities import (
+    get_nodes_from_node_names,
+    copy_graph,
+    visualize_graph,
+)
+from .bootstrap_utils import format_oriented_edge, make_graph
+
+
+_fci_bootstrap_data = None
+_fci_bootstrap_graph = None
+_fci_bootstrap_node_names = None
+_fci_bootstrap_sepsets = None
+_fci_bootstrap_kwargs = None
+_fci_bootstrap_n = None
+
+
+def _init_fci_bootstrap(data, graph, node_names, sepsets, fci_kwargs):
+    """Initializer to share data across FCI bootstrap worker processes."""
+    global _fci_bootstrap_data, _fci_bootstrap_graph
+    global _fci_bootstrap_node_names, _fci_bootstrap_sepsets
+    global _fci_bootstrap_kwargs, _fci_bootstrap_n
+    _fci_bootstrap_data = data
+    _fci_bootstrap_graph = graph
+    _fci_bootstrap_node_names = node_names
+    _fci_bootstrap_sepsets = sepsets
+    _fci_bootstrap_kwargs = fci_kwargs
+    _fci_bootstrap_n = data.shape[0]
+
+
+def _fci_bootstrap_worker(seed: int):
+    """Run a single FCI bootstrap iteration."""
+    sample = _fci_bootstrap_data.sample(
+        n=_fci_bootstrap_n, replace=True, random_state=seed
+    )
+    nodes = get_nodes_from_node_names(node_names=_fci_bootstrap_node_names)
+    g, _ = fci_orient_edges_from_graph_node_sepsets(
+        data=sample.values,
+        graph=copy_graph(_fci_bootstrap_graph),
+        nodes=nodes,
+        sepsets=_fci_bootstrap_sepsets,
+        **_fci_bootstrap_kwargs,
+    )
+
+    edges_repr = []
+    for edge in g.get_graph_edges():
+        n1 = edge.get_node1().get_name()
+        n2 = edge.get_node2().get_name()
+        e1 = edge.endpoint1
+        e2 = edge.endpoint2
+        if n1 <= n2:
+            edges_repr.append((n1, n2, e1.name, e2.name))
+        else:
+            edges_repr.append((n2, n1, e2.name, e1.name))
+    return edges_repr
+
+
+def bootstrap_fci_edge_stability(
+    data: pd.DataFrame,
+    resamples: int,
+    *,
+    graph: GeneralGraph,
+    nodes,
+    sepsets: Dict[Tuple[int, int], Any],
+    random_state: Optional[int] = None,
+    fci_kwargs: Optional[Dict[str, Any]] = None,
+    output_dir: Optional[str] = None,
+    n_jobs: Optional[int] = 1,
+) -> Tuple[
+    Dict[Tuple[str, str], Dict[str, float]],
+    Optional[Tuple[float, GeneralGraph, Dict[Tuple[str, str], Dict[str, float]]]],
+]:
+    """Estimate edge orientation probabilities via bootstrapped FCI runs."""
+
+    if resamples <= 0:
+        return {}, None
+
+    rng = np.random.RandomState(random_state)
+    counts: Dict[Tuple[str, str], Dict[str, int]] = {}
+    graph_counts: Dict[
+        Tuple[Tuple[str, str, str, str], ...], Tuple[int, List[Tuple[str, str, str, str]]]
+    ] = {}
+    fci_kwargs = fci_kwargs or {}
+
+    node_names = [node.get_name() for node in nodes]
+
+    if n_jobs is None or n_jobs <= 0:
+        n_jobs = 1
+    n_jobs = min(n_jobs, resamples)
+
+    seeds = rng.randint(0, 2**32, size=resamples)
+    _init_fci_bootstrap(data, graph, node_names, sepsets, fci_kwargs)
+    if n_jobs == 1:
+        results = [_fci_bootstrap_worker(s) for s in seeds]
+    else:
+        with mp.Pool(
+            processes=n_jobs,
+            initializer=_init_fci_bootstrap,
+            initargs=(data, graph, node_names, sepsets, fci_kwargs),
+        ) as pool:
+            results = pool.map(_fci_bootstrap_worker, seeds)
+
+    for edges_repr in results:
+        edges_repr_list = []
+        for n1, n2, e1, e2 in edges_repr:
+            pair = (n1, n2)
+            orient = f"{e1}-{e2}"
+            orient_counts = counts.setdefault(pair, {})
+            orient_counts[orient] = orient_counts.get(orient, 0) + 1
+            edges_repr_list.append((n1, n2, e1, e2))
+
+        key = tuple(sorted(edges_repr_list))
+        if key in graph_counts:
+            graph_counts[key] = (graph_counts[key][0] + 1, graph_counts[key][1])
+        else:
+            graph_counts[key] = (1, list(edges_repr_list))
+
+    probs = {
+        edge: {o: c / resamples for o, c in orient_counts.items()}
+        for edge, orient_counts in counts.items()
+    }
+
+    if probs:
+        print("Edge orientation probabilities from FCI bootstrap:")
+        for (a, b), orient_probs in probs.items():
+            for orient, p in orient_probs.items():
+                edge_str = format_oriented_edge(a, b, orient)
+                print(f"  {edge_str}: {p:.2f}")
+
+    best_graph_with_bootstrap = None
+    graph_probs: List[Tuple[float, GeneralGraph]] = []
+    if graph_counts:
+        for edges_repr, (count, edges_list) in graph_counts.items():
+            prob = count / resamples
+            graph_obj = make_graph(node_names, edges_list)
+            graph_probs.append((prob, graph_obj))
+
+        if graph_probs:
+            best_prob, best_graph = max(graph_probs, key=lambda x: x[0])
+            best_graph_with_bootstrap = (
+                best_prob,
+                copy.deepcopy(best_graph),
+                probs,
+            )
+
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
+            top_graphs = sorted(graph_probs, key=lambda x: x[0], reverse=True)[:3]
+            for idx, (prob, graph_obj) in enumerate(top_graphs, start=1):
+                title = f"Bootstrap Graph {idx} (p={prob:.2f})"
+                out_path = os.path.join(output_dir, f"graph_{idx}.png")
+                visualize_graph(
+                    graph_obj, title=title, show=False, output_path=out_path
+                )
+
+    return probs, best_graph_with_bootstrap
+

--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -24,9 +24,9 @@ from causal_pipe.preprocess.utilities import ensure_data_types
 from causal_pipe.sem.sem import (
     fit_sem_lavaan,
     search_best_graph_climber,
-    bootstrap_fci_edge_stability,
-    bootstrap_fas_edge_stability,
 )
+from causal_pipe.causal_discovery.fci_bootstrap import bootstrap_fci_edge_stability
+from causal_pipe.causal_discovery.fas_bootstrap import bootstrap_fas_edge_stability
 from causal_pipe.utilities.graph_utilities import (
     copy_graph,
     unify_edge_types_directed_undirected,

--- a/causal_pipe/sem/sem.py
+++ b/causal_pipe/sem/sem.py
@@ -1,23 +1,22 @@
 import warnings
-from typing import List, Optional, Tuple, Dict, Any, Set
+from typing import List, Optional, Tuple, Dict, Any
 
 import copy
-import os
+import multiprocessing as mp
 import numpy as np
 import pandas as pd
 from causallearn.graph.GeneralGraph import GeneralGraph
-from bcsl.fci import fci_orient_edges_from_graph_node_sepsets
-from causallearn.utils.FAS import fas
-from causallearn.utils.cit import CIT
 
-from causal_pipe.causal_discovery.static_causal_discovery import visualize_graph
+from causal_pipe.causal_discovery.bootstrap_utils import (
+    format_oriented_edge,
+    make_graph,
+)
 from causal_pipe.sem.hill_climber import GraphHillClimber
 from causal_pipe.utilities.graph_utilities import (
     dataframe_to_json_compatible_list,
     general_graph_to_sem_model,
     get_neighbors_general_graph,
-    get_nodes_from_node_names,
-    copy_graph, duplicate_circle_endpoints_probabilities,
+    duplicate_circle_endpoints_probabilities,
 )
 from causal_pipe.utilities.model_comparison_utilities import (
     BETTER_MODEL_1,
@@ -26,30 +25,6 @@ from causal_pipe.utilities.model_comparison_utilities import (
 )
 
 
-ENDPOINT_SYMBOLS = {"TAIL": "-", "ARROW": ">", "CIRCLE": "o"}
-
-
-def _format_oriented_edge(a: str, b: str, orient: str) -> str:
-    e1, e2 = orient.split("-")
-    if e1 == "TAIL" and e2 == "ARROW":
-        return f"{a} -> {b}"
-    if e1 == "ARROW" and e2 == "TAIL":
-        return f"{a} <- {b}"
-    if e1 == "ARROW" and e2 == "ARROW":
-        return f"{a} <-> {b}"
-    if e1 == "TAIL" and e2 == "TAIL":
-        return f"{a} -- {b}"
-    if e1 == "CIRCLE" and e2 == "ARROW":
-        return f"{a} o-> {b}"
-    if e1 == "ARROW" and e2 == "CIRCLE":
-        return f"{a} <-o {b}"
-    if e1 == "CIRCLE" and e2 == "TAIL":
-        return f"{a} o- {b}"
-    if e1 == "TAIL" and e2 == "CIRCLE":
-        return f"{a} -o {b}"
-    if e1 == "CIRCLE" and e2 == "CIRCLE":
-        return f"{a} o-o {b}"
-    return f"{a} {e1}-{e2} {b}"
 
 
 def format_ordered_for_sem(data: pd.DataFrame, ordered: List[str]) -> pd.DataFrame:
@@ -893,259 +868,63 @@ def nodes_names_from_data(data: pd.DataFrame) -> List[str]:
         )
 
 
-def bootstrap_fas_edge_stability(
-    data: pd.DataFrame,
-    resamples: int,
-    *,
-    random_state: Optional[int] = None,
-    fas_kwargs: Optional[Dict[str, Any]] = None,
-    output_dir: Optional[str] = None,
-) -> Tuple[
-    Dict[Tuple[str, str], float],
-    Optional[
-        Tuple[
-            float,
-            GeneralGraph,
-            Dict[Tuple[str, str], float],
-            Dict[Tuple[int, int], Set[int]],
-        ]
-    ],
-]:
-    """Estimate edge presence probabilities via bootstrapped FAS runs.
+# --- Multiprocessing helpers -------------------------------------------------
 
-    Returns
-    -------
-    Tuple
-        - Mapping from unordered node pairs to edge presence probabilities across
-          bootstrap runs.
-        - Information about the most probable bootstrapped graph as a tuple
-          ``(probability, graph, edge_probabilities, sepsets)`` or ``None`` if no
-          graphs were generated.
-    """
 
-    if resamples <= 0:
-        return {}, None
 
-    n = data.shape[0]
-    rng = np.random.RandomState(random_state)
-    counts: Dict[Tuple[str, str], int] = {}
-    graph_counts: Dict[
-        Tuple[Tuple[str, str], ...], Tuple[int, GeneralGraph, Dict[Tuple[int, int], Set[int]]]
-    ] = {}
-    fas_kwargs = fas_kwargs or {}
+_hc_data = None
+_hc_node_names = None
+_hc_estimator = None
+_hc_respect_pag = None
+_hc_initial_graph = None
+_hc_max_iter = None
+_hc_n = None
 
-    node_names = list(data.columns)
-    nodes = get_nodes_from_node_names(node_names=node_names)
-    ci_method = fas_kwargs.pop("conditional_independence_method", "fisherz")
 
-    for _ in range(resamples):
-        sample = data.sample(n=n, replace=True, random_state=rng.randint(0, 2**32))
-        cit = CIT(data=sample.values, method=ci_method)
-        g, sepsets, _ = fas(
-            data=sample.values,
-            nodes=nodes,
-            independence_test_method=cit,
-            **fas_kwargs,
-        )
+def _init_hc_bootstrap(data, node_names, estimator, respect_pag, initial_graph, max_iter):
+    """Initializer to share data across hill-climb bootstrap worker processes."""
+    global _hc_data, _hc_node_names, _hc_estimator
+    global _hc_respect_pag, _hc_initial_graph, _hc_max_iter, _hc_n
+    _hc_data = data
+    _hc_node_names = node_names
+    _hc_estimator = estimator
+    _hc_respect_pag = respect_pag
+    _hc_initial_graph = initial_graph
+    _hc_max_iter = max_iter
+    _hc_n = data.shape[0]
 
-        edges_repr = []
-        for edge in g.get_graph_edges():
-            n1 = edge.get_node1().get_name()
-            n2 = edge.get_node2().get_name()
-            if n1 <= n2:
-                pair = (n1, n2)
-            else:
-                pair = (n2, n1)
-            counts[pair] = counts.get(pair, 0) + 1
-            edges_repr.append(pair)
 
-        key = tuple(sorted(edges_repr))
-        if key in graph_counts:
-            graph_counts[key] = (
-                graph_counts[key][0] + 1,
-                graph_counts[key][1],
-                graph_counts[key][2],
-            )
+def _hc_bootstrap_worker(seed: int):
+    """Run a single hill-climb bootstrap iteration."""
+    sample = _hc_data.sample(n=_hc_n, replace=True, random_state=seed)
+    sem_score_i = SEMScore(
+        data=sample,
+        estimator=_hc_estimator,
+        return_metrics=False,
+        ordered=None,
+    )
+    hill_climber_i = GraphHillClimber(
+        score_function=sem_score_i,
+        get_neighbors_func=get_neighbors_general_graph,
+        node_names=_hc_node_names,
+        keep_initially_oriented_edges=True,
+        respect_pag=_hc_respect_pag,
+    )
+    graph_copy = copy.deepcopy(_hc_initial_graph)
+    result_graph = hill_climber_i.run(initial_graph=graph_copy, max_iter=_hc_max_iter)
+
+    edges_repr = []
+    for edge in result_graph.get_graph_edges():
+        n1 = edge.get_node1().get_name()
+        n2 = edge.get_node2().get_name()
+        e1 = edge.endpoint1
+        e2 = edge.endpoint2
+        if n1 <= n2:
+            edges_repr.append((n1, n2, e1.name, e2.name))
         else:
-            graph_counts[key] = (1, copy.deepcopy(g), copy.deepcopy(sepsets))
+            edges_repr.append((n2, n1, e2.name, e1.name))
+    return edges_repr
 
-    probs = {edge: c / resamples for edge, c in counts.items()}
-
-    if probs:
-        print("Edge presence probabilities from FAS bootstrap:")
-        for (a, b), p in probs.items():
-            print(f"  {a} -- {b}: {p:.2f}")
-
-    best_graph_with_bootstrap = None
-    graph_probs: List[Tuple[float, GeneralGraph, Dict[Tuple[int, int], Set[int]]]] = []
-    if graph_counts:
-        # for edges_repr, (_, graph_obj) in graph_counts.items():
-        #     prob = 1.0
-        #     for n1, n2 in edges_repr:
-        #         prob *= probs.get((n1, n2), 0.0)
-        #     graph_probs.append((prob, graph_obj))
-        # Graph probs is simply the frequency of the graph in bootstrap samples
-        for edges_repr, (count, graph_obj, seps) in graph_counts.items():
-            prob = count / resamples
-            graph_probs.append((prob, graph_obj, seps))
-
-        if graph_probs:
-            best_prob, best_graph, best_sepsets = max(
-                graph_probs, key=lambda x: x[0]
-            )
-            best_graph_with_bootstrap = (
-                best_prob,
-                copy.deepcopy(best_graph),
-                probs,
-                copy.deepcopy(best_sepsets),
-            )
-
-        if output_dir:
-            os.makedirs(output_dir, exist_ok=True)
-            top_graphs = sorted(graph_probs, key=lambda x: x[0], reverse=True)[:3]
-            for idx, (prob, graph_obj, _) in enumerate(top_graphs, start=1):
-                title = f"Bootstrap Graph {idx} (p={prob:.2f})"
-                out_path = os.path.join(output_dir, f"graph_{idx}.png")
-                visualize_graph(
-                    graph_obj, title=title, show=False, output_path=out_path
-                )
-
-    return probs, best_graph_with_bootstrap
-
-
-def bootstrap_fci_edge_stability(
-    data: pd.DataFrame,
-    resamples: int,
-    *,
-    graph: GeneralGraph,
-    nodes,
-    sepsets: Dict[Tuple[int, int], Set[int]],
-    random_state: Optional[int] = None,
-    fci_kwargs: Optional[Dict[str, Any]] = None,
-    output_dir: Optional[str] = None,
-) -> Tuple[
-    Dict[Tuple[str, str], Dict[str, float]],
-    Optional[Tuple[float, GeneralGraph, Dict[Tuple[str, str], Dict[str, float]]]],
-]:
-    """Estimate edge orientation probabilities via bootstrapped FCI runs.
-
-    Parameters
-    ----------
-    data : pd.DataFrame
-        Input dataset used for resampling.
-    resamples : int
-        Number of bootstrap resamples to draw. If ``resamples`` is ``0`` the
-        function returns an empty dictionary.
-    graph : GeneralGraph
-        Unoriented graph to be used as the starting point for FCI orientation.
-    nodes : List
-        Node objects corresponding to the columns of ``data``.
-    sepsets : Dict[Tuple[int, int], Set[int]]
-        Separation sets associated with ``graph``.
-    random_state : Optional[int], default ``None``
-        Seed for the random number generator to ensure reproducibility.
-    fci_kwargs : Optional[Dict[str, Any]], default ``None``
-        Additional keyword arguments passed directly to
-        :func:`fci_orient_edges_from_graph_node_sepsets`.
-    output_dir : Optional[str], default ``None``
-        Directory to save the three bootstrapped graphs with the highest
-        product of edge orientation probabilities. When ``None`` no graphs
-        are saved.
-
-    Returns
-    -------
-    Tuple[Dict[Tuple[str, str], Dict[str, float]], Optional[Tuple[float, GeneralGraph, Dict[Tuple[str, str], Dict[str, float]]]]]
-        - Mapping from unordered node pairs to orientation probabilities across
-          bootstrap runs. Orientation keys are strings of the form
-          ``"{endpoint1}-{endpoint2}"`` where ``endpoint1`` and ``endpoint2``
-          are :class:`~causallearn.graph.Endpoint` names (e.g., ``"TAIL-ARROW"``
-          for a directed edge from the first node to the second).
-        - Information about the most probable bootstrapped graph as a tuple
-          ``(probability, graph, edge_probabilities)`` or ``None`` if no graphs
-          were generated.
-    """
-
-    if resamples <= 0:
-        return {}, None
-
-    n = data.shape[0]
-    rng = np.random.RandomState(random_state)
-    counts: Dict[Tuple[str, str], Dict[str, int]] = {}
-    graph_counts: Dict[Tuple[Tuple[str, str, str, str], ...], Tuple[int, GeneralGraph]] = {}
-    fci_kwargs = fci_kwargs or {}
-
-    for _ in range(resamples):
-        sample = data.sample(n=n, replace=True, random_state=rng.randint(0, 2**32))
-        g, _ = fci_orient_edges_from_graph_node_sepsets(
-            data=sample.values,
-            graph=copy_graph(graph),
-            nodes=nodes,
-            sepsets=sepsets,
-            **fci_kwargs,
-        )
-
-        edges_repr = []
-        for edge in g.get_graph_edges():
-            n1 = edge.get_node1().get_name()
-            n2 = edge.get_node2().get_name()
-            e1 = edge.endpoint1
-            e2 = edge.endpoint2
-            if n1 <= n2:
-                pair = (n1, n2)
-                orient = f"{e1.name}-{e2.name}"
-                edge_repr = (n1, n2, e1.name, e2.name)
-            else:
-                pair = (n2, n1)
-                orient = f"{e2.name}-{e1.name}"
-                edge_repr = (n2, n1, e2.name, e1.name)
-            edges_repr.append(edge_repr)
-            orient_counts = counts.setdefault(pair, {})
-            orient_counts[orient] = orient_counts.get(orient, 0) + 1
-
-        key = tuple(sorted(edges_repr))
-        if key in graph_counts:
-            graph_counts[key] = (graph_counts[key][0] + 1, graph_counts[key][1])
-        else:
-            graph_counts[key] = (1, copy.deepcopy(g))
-
-    probs = {
-        edge: {o: c / resamples for o, c in orient_counts.items()}
-        for edge, orient_counts in counts.items()
-    }
-
-    if probs:
-        print("Edge orientation probabilities from FCI bootstrap:")
-        for (a, b), orient_probs in probs.items():
-            for orient, p in orient_probs.items():
-                edge_str = _format_oriented_edge(a, b, orient)
-                print(f"  {edge_str}: {p:.2f}")
-
-    best_graph_with_bootstrap = None
-    graph_probs: List[Tuple[float, GeneralGraph]] = []
-    if graph_counts:
-        for edges_repr, (count, graph_obj) in graph_counts.items():
-            prob = count / resamples
-            graph_probs.append((prob, graph_obj))
-
-        if graph_probs:
-            best_prob, best_graph = max(graph_probs, key=lambda x: x[0])
-            best_graph_with_bootstrap = (
-                best_prob,
-                copy.deepcopy(best_graph),
-                probs,
-            )
-
-        if output_dir:
-            os.makedirs(output_dir, exist_ok=True)
-            top_graphs = sorted(graph_probs, key=lambda x: x[0], reverse=True)[:3]
-            for idx, (prob, graph_obj) in enumerate(top_graphs, start=1):
-                title = f"Bootstrap Graph {idx} (p={prob:.2f})"
-                out_path = os.path.join(output_dir, f"graph_{idx}.png")
-                visualize_graph(
-                    graph_obj, title=title, show=False, output_path=out_path
-                )
-
-    return probs, best_graph_with_bootstrap
 
 
 def search_best_graph_climber(
@@ -1162,11 +941,12 @@ def search_best_graph_climber(
     whitelist_pairs: Optional[pd.DataFrame] = None,
     forbid_pairs: Optional[pd.DataFrame] = None,
     same_occasion_regex: Optional[str] = None,
+    ordered: Optional[List[str]] = None,
     *,
     respect_pag: bool = False,
     bootstrap_resamples: int = 0,
     bootstrap_random_state: Optional[int] = None,
-    **kwargs,
+    n_jobs: Optional[int] = 1,
 ) -> Tuple[GeneralGraph, Dict[str, Any]]:
     """
     Searches for the best graph structure using hill-climbing based on SEM fit.
@@ -1192,10 +972,10 @@ def search_best_graph_climber(
         edge orientation probabilities after hill climbing.
     bootstrap_random_state : Optional[int], optional
         Seed for the hill-climb bootstrap resampling procedure.
-    hc_bootstrap_output_dir : Optional[str], optional
-        Directory to save the three bootstrapped graphs with the highest
-        product of edge orientation probabilities. When ``None`` no graphs are
-        saved.
+    n_jobs : Optional[int], optional
+        Number of worker processes to use for bootstrapped hill climbing. When
+        ``1`` the computation is run sequentially; larger values enable
+        multiprocessing.
 
 
     Returns
@@ -1214,8 +994,6 @@ def search_best_graph_climber(
               bootstrapping is requested, orientation probabilities for edges
               after hill climbing.
     """
-    ordered = None
-
     if node_names is None:
         node_names = nodes_names_from_data(data)
 
@@ -1237,6 +1015,7 @@ def search_best_graph_climber(
     best_score = {}
     best_graph = None
     baseline_score = None
+
     if not bootstrap_resamples:
         best_graph = hill_climber.run(initial_graph=initial_graph_copy, max_iter=max_iter)
         best_score = sem_score.exhaustive_results(best_graph)
@@ -1244,51 +1023,41 @@ def search_best_graph_climber(
     elif not isinstance(bootstrap_resamples, int) or bootstrap_resamples < 0:
         raise ValueError("bootstrap_resamples must be a non-negative integer.")
     else:
-        n = data.shape[0]
         rng = np.random.RandomState(bootstrap_random_state)
         counts: Dict[Tuple[str, str], Dict[str, int]] = {}
-        graph_counts: Dict[Tuple[Tuple[str, str, str, str], ...], Tuple[int, GeneralGraph]] = {}
-        for i in range(bootstrap_resamples):
-            sample = data.sample(n=n, replace=True, random_state=rng.randint(0, 2**32))
-            sem_score_i = SEMScore(
-                data=sample,
-                estimator=estimator,
-                return_metrics=False,
-                ordered=ordered,
-            )
-            hill_climber_i = GraphHillClimber(
-                score_function=sem_score_i,
-                get_neighbors_func=get_neighbors_general_graph,
-                node_names=node_names,
-                keep_initially_oriented_edges=True,
-                respect_pag=respect_pag,
-            )
-            graph_copy = copy.deepcopy(initial_graph)
-            result_graph = hill_climber_i.run(
-                initial_graph=graph_copy, max_iter=max_iter
-            )
-            edges_repr = []
-            for edge in result_graph.get_graph_edges():
-                n1 = edge.get_node1().get_name()
-                n2 = edge.get_node2().get_name()
-                e1 = edge.endpoint1
-                e2 = edge.endpoint2
-                if n1 <= n2:
-                    pair = (n1, n2)
-                    orient = f"{e1.name}-{e2.name}"
-                    edge_repr = (n1, n2, e1.name, e2.name)
-                else:
-                    pair = (n2, n1)
-                    orient = f"{e2.name}-{e1.name}"
-                    edge_repr = (n2, n1, e2.name, e1.name)
-                edges_repr.append(edge_repr)
+        graph_counts: Dict[
+            Tuple[Tuple[str, str, str, str], ...], Tuple[int, List[Tuple[str, str, str, str]]]
+        ] = {}
+
+        if n_jobs is None or n_jobs <= 0:
+            n_jobs = 1
+        n_jobs = min(n_jobs, bootstrap_resamples)
+
+        seeds = rng.randint(0, 2**32, size=bootstrap_resamples)
+        _init_hc_bootstrap(data, node_names, estimator, respect_pag, initial_graph, max_iter)
+        if n_jobs == 1:
+            results = [_hc_bootstrap_worker(s) for s in seeds]
+        else:
+            with mp.Pool(
+                processes=n_jobs,
+                initializer=_init_hc_bootstrap,
+                initargs=(data, node_names, estimator, respect_pag, initial_graph, max_iter),
+            ) as pool:
+                results = pool.map(_hc_bootstrap_worker, seeds)
+
+        for edges_repr in results:
+            edges_repr_list = []
+            for n1, n2, e1, e2 in edges_repr:
+                pair = (n1, n2)
+                orient = f"{e1}-{e2}"
                 orient_counts = counts.setdefault(pair, {})
                 orient_counts[orient] = orient_counts.get(orient, 0) + 1
-            key = tuple(sorted(edges_repr))
+                edges_repr_list.append((n1, n2, e1, e2))
+            key = tuple(sorted(edges_repr_list))
             if key in graph_counts:
                 graph_counts[key] = (graph_counts[key][0] + 1, graph_counts[key][1])
             else:
-                graph_counts[key] = (1, copy.deepcopy(result_graph))
+                graph_counts[key] = (1, list(edges_repr_list))
 
         hc_edge_orientation_probabilities = {
             edge: {o: c / bootstrap_resamples for o, c in orient_counts.items()}
@@ -1303,13 +1072,14 @@ def search_best_graph_climber(
             print("Hill-climb bootstrap edge orientation probabilities:")
             for (a, b), orient_probs in hc_edge_orientation_probabilities.items():
                 for orient, p in orient_probs.items():
-                    edge_str = _format_oriented_edge(a, b, orient)
+                    edge_str = format_oriented_edge(a, b, orient)
                     print(f"  {edge_str}: {p:.2f}")
 
         graph_probs: List[Tuple[float, GeneralGraph]] = []
         if graph_counts:
-            for edges_repr, (count, graph_obj) in graph_counts.items():
+            for edges_repr, (count, edges_list) in graph_counts.items():
                 prob = count / bootstrap_resamples
+                graph_obj = make_graph(node_names, edges_list)
                 graph_probs.append((prob, graph_obj))
 
             if graph_probs:

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -467,11 +467,12 @@ search_best_graph_climber(
     whitelist_pairs: Optional[pd.DataFrame] = None,
     forbid_pairs: Optional[pd.DataFrame] = None,
     same_occasion_regex: Optional[str] = None,
+    ordered: Optional[List[str]] = None,
     *,
     respect_pag: bool = False,
     bootstrap_resamples: int = 0,
     bootstrap_random_state: Optional[int] = None,
-    **kwargs,
+    n_jobs: Optional[int] = 1,
 ) -> Tuple[GeneralGraph, Dict[str, Any]]
 ```
 
@@ -489,10 +490,11 @@ search_best_graph_climber(
     - `whitelist_pairs` (`Optional[pd.DataFrame]`, default `None`): Optional whitelist of pairs (`lhs`, `rhs`).
     - `forbid_pairs` (`Optional[pd.DataFrame]`, default `None`): Optional blocklist of pairs.
     - `same_occasion_regex` (`Optional[str]`, default `None`): Regex enforcing same-occasion pairs unless whitelisted.
+    - `ordered` (`Optional[List[str]]`, default `None`): Ordered categorical variables in the data.
     - `respect_pag` (`bool`, default `False`): When `True`, the search preserves PAG marks (no change to ↔, →, —; only resolves circle endpoints consistent with PAG semantics).
-    - `bootstrap_resamples` (`int`, default `0`): If greater than `0`, run the SEM hill climber on bootstrap resamples to estimate orientation probabilities after hill climbing. The three bootstrapped graphs with the highest product of edge orientation probabilities are stored in `sem_hc_bootstrap/`.
+    - `bootstrap_resamples` (`int`, default `0`): If greater than `0`, run the SEM hill climber on bootstrap resamples to estimate orientation probabilities after hill climbing.
     - `bootstrap_random_state` (`Optional[int]`, default `None`): Seed for the hill-climb bootstrap resampling procedure.
-    - `**kwargs`: Additional keyword arguments.
+    - `n_jobs` (`Optional[int]`, default `1`): Number of worker processes to use for bootstrapped hill climbing.
 
 - **Returns:**
     - `Tuple[GeneralGraph, Dict[str, Any]]`: A tuple containing:


### PR DESCRIPTION
## Summary
- split FCI and FAS bootstrap routines into dedicated causal_discovery modules
- streamline SEM hill-climb bootstrap without `hc_bootstrap_output_dir`
- update documentation and imports to reflect new bootstrap structure

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_b_68bceb7ae2ac83309d67d1dd7ee91f01