### PR TITLE
Improve FAS bootstrap stability and performance

### DIFF
--- a/causal_pipe/causal_discovery/fas_bootstrap.py
+++ b/causal_pipe/causal_discovery/fas_bootstrap.py
@@ -1,9 +1,10 @@
 """Bootstrap edge stability for the FAS algorithm."""
 
 from typing import Dict, Tuple, Optional, List, Any, Set
-import copy
 import os
 import multiprocessing as mp
+from collections import Counter, defaultdict
+
 import numpy as np
 import pandas as pd
 from causallearn.utils.cit import CIT
@@ -14,8 +15,13 @@ from causal_pipe.utilities.graph_utilities import get_nodes_from_node_names
 from .bootstrap_utils import make_graph
 from .static_causal_discovery import visualize_graph
 
+# Limit BLAS thread usage in child processes to avoid oversubscription
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+
 _fas_bootstrap_data = None
-_fas_bootstrap_node_names = None
+_fas_bootstrap_nodes = None
 _fas_bootstrap_ci_method = None
 _fas_bootstrap_kwargs = None
 _fas_bootstrap_n = None
@@ -23,13 +29,27 @@ _fas_bootstrap_n = None
 
 def _init_fas_bootstrap(data, node_names, ci_method, fas_kwargs):
     """Initializer to share data across FAS bootstrap worker processes."""
-    global _fas_bootstrap_data, _fas_bootstrap_node_names
+    global _fas_bootstrap_data, _fas_bootstrap_nodes
     global _fas_bootstrap_ci_method, _fas_bootstrap_kwargs, _fas_bootstrap_n
     _fas_bootstrap_data = data
-    _fas_bootstrap_node_names = node_names
+    _fas_bootstrap_nodes = get_nodes_from_node_names(node_names=node_names)
     _fas_bootstrap_ci_method = ci_method
     _fas_bootstrap_kwargs = fas_kwargs
     _fas_bootstrap_n = data.shape[0]
+
+
+def _to_matrix(df: pd.DataFrame) -> np.ndarray:
+    """Convert DataFrame to a numeric matrix based on CI test method."""
+    method = (_fas_bootstrap_ci_method or "").lower()
+    if method in {"gsq", "chisq", "g2"}:
+        def _enc(s):
+            if pd.api.types.is_categorical_dtype(s):
+                return s.cat.codes
+            if pd.api.types.is_object_dtype(s):
+                return s.astype("category").cat.codes
+            return s.astype("int64")
+        return df.apply(_enc).to_numpy(copy=False)
+    return df.astype("float64").to_numpy(copy=False)
 
 
 def _fas_bootstrap_worker(seed: int):
@@ -37,11 +57,11 @@ def _fas_bootstrap_worker(seed: int):
     sample = _fas_bootstrap_data.sample(
         n=_fas_bootstrap_n, replace=True, random_state=seed
     )
-    nodes = get_nodes_from_node_names(node_names=_fas_bootstrap_node_names)
-    cit = CIT(data=sample.values, method=_fas_bootstrap_ci_method)
+    sample_matrix = _to_matrix(sample)
+    cit = CIT(data=sample_matrix, method=_fas_bootstrap_ci_method)
     g, sepsets, _ = fas(
-        data=sample.values,
-        nodes=nodes,
+        data=sample_matrix,
+        nodes=_fas_bootstrap_nodes,
         independence_test_method=cit,
         **_fas_bootstrap_kwargs,
     )
@@ -83,81 +103,84 @@ def bootstrap_fas_edge_stability(
     if resamples <= 0:
         return {}, None
 
-    rng = np.random.RandomState(random_state)
-    counts: Dict[Tuple[str, str], int] = {}
-    graph_counts: Dict[
-        Tuple[Tuple[str, str], ...], Tuple[int, List[Tuple[str, str]], Dict[Tuple[int, int], Set[int]]]
-    ] = {}
-    fas_kwargs = fas_kwargs or {}
+    rng = np.random.default_rng(random_state)
+    counts = defaultdict(int)
+    graph_counts: Dict[Tuple[Tuple[str, str], ...], Tuple[int, List[Tuple[str, str]]]] = {}
+    sepset_counts = defaultdict(Counter)
 
+    fas_kwargs = dict(fas_kwargs or {})
     node_names = list(data.columns)
     ci_method = fas_kwargs.pop("conditional_independence_method", "fisherz")
 
-    if n_jobs is None or n_jobs <= 0:
-        n_jobs = 1
+    if n_jobs in (None, 0, -1):
+        n_jobs = os.cpu_count() or 1
     n_jobs = min(n_jobs, resamples)
 
-    seeds = rng.randint(0, 2**32, size=resamples)
-    _init_fas_bootstrap(data, node_names, ci_method, fas_kwargs)
-    if n_jobs == 1:
-        results = [_fas_bootstrap_worker(s) for s in seeds]
-    else:
-        with mp.Pool(
-            processes=n_jobs,
-            initializer=_init_fas_bootstrap,
-            initargs=(data, node_names, ci_method, fas_kwargs),
-        ) as pool:
-            results = pool.map(_fas_bootstrap_worker, seeds)
+    seeds = rng.integers(0, 2**32, size=resamples, dtype=np.uint32).tolist()
 
-    for edges_repr, sepsets in results:
+    # initialise globals for single-process path
+    _init_fas_bootstrap(data, node_names, ci_method, fas_kwargs)
+
+    def _iter_results():
+        if n_jobs == 1:
+            for s in seeds:
+                yield _fas_bootstrap_worker(int(s))
+        else:
+            chunksize = max(1, len(seeds) // (n_jobs * 4))
+            with mp.Pool(
+                processes=n_jobs,
+                initializer=_init_fas_bootstrap,
+                initargs=(data, node_names, ci_method, fas_kwargs),
+                maxtasksperchild=250,
+            ) as pool:
+                for r in pool.imap_unordered(_fas_bootstrap_worker, seeds, chunksize=chunksize):
+                    yield r
+
+    for edges_repr, sepsets in _iter_results():
         for pair in edges_repr:
-            counts[pair] = counts.get(pair, 0) + 1
+            counts[pair] += 1
         key = tuple(sorted(edges_repr))
         if key in graph_counts:
-            graph_counts[key] = (
-                graph_counts[key][0] + 1,
-                graph_counts[key][1],
-                graph_counts[key][2],
-            )
+            graph_counts[key] = (graph_counts[key][0] + 1, graph_counts[key][1])
         else:
-            graph_counts[key] = (1, list(edges_repr), copy.deepcopy(sepsets))
+            graph_counts[key] = (1, list(edges_repr))
+        for (i, j), S in sepsets.items():
+            if i > j:
+                i, j = j, i
+            sepset_counts[(i, j)][frozenset(S)] += 1
 
     probs = {edge: c / resamples for edge, c in counts.items()}
 
-    if probs:
-        print("Edge presence probabilities from FAS bootstrap:")
-        for (a, b), p in probs.items():
-            print(f"  {a} -- {b}: {p:.2f}")
-
     best_graph_with_bootstrap = None
-    graph_probs: List[Tuple[float, GeneralGraph, Dict[Tuple[int, int], Set[int]]]] = []
     if graph_counts:
-        for edges_repr, (count, edges_list, seps) in graph_counts.items():
-            prob = count / resamples
-            graph_obj = make_graph(
-                node_names, [(a, b, "TAIL", "TAIL") for a, b in edges_list]
-            )
-            graph_probs.append((prob, graph_obj, seps))
-
-        if graph_probs:
-            best_prob, best_graph, best_sepsets = max(
-                graph_probs, key=lambda x: x[0]
-            )
-            best_graph_with_bootstrap = (
-                best_prob,
-                copy.deepcopy(best_graph),
-                probs,
-                copy.deepcopy(best_sepsets),
-            )
+        prob_graphs = sorted(
+            (
+                (cnt / resamples, edges_list)
+                for _edges_key, (cnt, edges_list) in graph_counts.items()
+            ),
+            reverse=True,
+        )
+        best_prob, best_edges = prob_graphs[0]
+        graph_obj = make_graph(
+            node_names, [(a, b, "TAIL", "TAIL") for a, b in best_edges]
+        )
+        best_sepsets = {
+            k: set(max(cnt.items(), key=lambda x: x[1])[0])
+            for k, cnt in sepset_counts.items()
+        }
+        best_graph_with_bootstrap = (best_prob, graph_obj, probs, best_sepsets)
 
         if output_dir:
             os.makedirs(output_dir, exist_ok=True)
-            top_graphs = sorted(graph_probs, key=lambda x: x[0], reverse=True)[:3]
-            for idx, (prob, graph_obj, _) in enumerate(top_graphs, start=1):
-                title = f"Bootstrap Graph {idx} (p={prob:.2f})"
-                out_path = os.path.join(output_dir, f"graph_{idx}.png")
+            for idx, (p, edges) in enumerate(prob_graphs[:3], start=1):
+                g = make_graph(
+                    node_names, [(a, b, "TAIL", "TAIL") for a, b in edges]
+                )
                 visualize_graph(
-                    graph_obj, title=title, show=False, output_path=out_path
+                    g,
+                    title=f"Bootstrap Graph {idx} (p={p:.2f})",
+                    show=False,
+                    output_path=os.path.join(output_dir, f"graph_{idx}.png"),
                 )
 
     return probs, best_graph_with_bootstrap


### PR DESCRIPTION
## Summary
- avoid mutating caller kwargs and expose CI method
- stream bootstrap results with multiprocessing and aggregate modal sepsets
- normalize data dtypes and cache nodes per worker; limit BLAS thread usage

## Testing
- ⚠️ `pytest tests/test_bootstrap_edge_stability.py::test_bootstrap_fas_edge_stability_returns_probabilities -q` *(missing bcsl dependency)*

------
https://chatgpt.com/codex/tasks/task_b_68bd006bb09483309b85d68732b8689d