### PR TITLE
Add edge stability threshold for FAS bootstrap

### DIFF
--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -392,9 +392,8 @@ class CausalPipe:
                         resamples=self.skeleton_method.bootstrap_resamples,
                         random_state=self.skeleton_method.bootstrap_random_state,
                         fas_kwargs=fas_kwargs,
-                        output_dir=os.path.join(
-                            self.output_path, "fas_bootstrap"
-                        ),
+                        output_dir=os.path.join(self.output_path, "fas_bootstrap"),
+                        edge_threshold=self.skeleton_method.bootstrap_edge_threshold,
                     )
                     if self.best_graph_with_fas_bootstrap:
                         prob, best_graph_bootstrap, edge_probs, sepsets_bootstrap = (
@@ -405,8 +404,10 @@ class CausalPipe:
                         oriented_probs = {
                             k: {"TAIL-TAIL": v} for k, v in edge_probs.items()
                         }
-                        prob_graph, edges_with_probabilities = add_edge_probabilities_to_graph(
-                            best_graph_bootstrap, oriented_probs
+                        prob_graph, edges_with_probabilities = (
+                            add_edge_probabilities_to_graph(
+                                best_graph_bootstrap, oriented_probs
+                            )
                         )
                         visualize_graph(
                             prob_graph,
@@ -501,17 +502,17 @@ class CausalPipe:
                         sepsets=self.sepsets,
                         random_state=self.orientation_method.bootstrap_random_state,
                         fci_kwargs=fci_kwargs,
-                        output_dir=os.path.join(
-                            self.output_path, "fci_bootstrap"
-                        ),
+                        output_dir=os.path.join(self.output_path, "fci_bootstrap"),
                     )
                     if self.best_graph_with_fci_bootstrap:
                         prob, best_graph_bootstrap, edge_probs = (
                             self.best_graph_with_fci_bootstrap
                         )
                         self.directed_graph = best_graph_bootstrap
-                        prob_graph, edges_with_probabilities = add_edge_probabilities_to_graph(
-                            best_graph_bootstrap, edge_probs
+                        prob_graph, edges_with_probabilities = (
+                            add_edge_probabilities_to_graph(
+                                best_graph_bootstrap, edge_probs
+                            )
                         )
                         visualize_graph(
                             prob_graph,
@@ -651,9 +652,11 @@ class CausalPipe:
                         ordered=ordered,
                         exogenous_vars_model_1=exogenous_vars,
                     )
-                    coef_graph, edges_with_coefficients = add_edge_coefficients_from_sem_fit(
-                        directed_graph,
-                        model_output=self.causal_effects[method.name],
+                    coef_graph, edges_with_coefficients = (
+                        add_edge_coefficients_from_sem_fit(
+                            directed_graph,
+                            model_output=self.causal_effects[method.name],
+                        )
                     )
                     out_sem_dir = os.path.join(self.output_path, "causal_effect", "sem")
                     os.makedirs(out_sem_dir, exist_ok=True)
@@ -734,9 +737,11 @@ class CausalPipe:
                         show=show_plot,
                         output_path=os.path.join(out_sem_dir, "best_graph.png"),
                     )
-                    coef_graph, edges_with_coefficients = add_edge_coefficients_from_sem_fit(
-                        best_graph,
-                        model_output=self.causal_effects[method.name]["summary"],
+                    coef_graph, edges_with_coefficients = (
+                        add_edge_coefficients_from_sem_fit(
+                            best_graph,
+                            model_output=self.causal_effects[method.name]["summary"],
+                        )
                     )
                     visualize_graph(
                         coef_graph,
@@ -757,9 +762,7 @@ class CausalPipe:
                             edges_with_coef_prob,
                         ) = add_edge_coefficients_and_probabilities_from_sem_fit(
                             best_graph_hc,
-                            model_output=self.causal_effects[method.name][
-                                "summary"
-                            ],
+                            model_output=self.causal_effects[method.name]["summary"],
                             edge_probabilities=edge_probs_hc,
                         )
                         visualize_graph(
@@ -774,21 +777,19 @@ class CausalPipe:
                         )
                     if sem_results.get("top_graphs_with_hc_bootstrap"):
                         top_graphs = sem_results["top_graphs_with_hc_bootstrap"]
-                        edge_probs = sem_results.get("hc_bootstrap_edge_probabilities", {})
+                        edge_probs = sem_results.get(
+                            "hc_bootstrap_edge_probabilities", {}
+                        )
                         for i, (prob, top_graph) in enumerate(top_graphs):
                             (
                                 coef_prob_graph,
                                 edges_with_coef_prob,
-                            ) = add_edge_probabilities_to_graph(
-                                top_graph, edge_probs
-                            )
+                            ) = add_edge_probabilities_to_graph(top_graph, edge_probs)
                             visualize_graph(
                                 coef_prob_graph,
                                 edges=edges_with_coef_prob,
                                 title=f"Top {i+1} HC Bootstrap Graph (p={prob:.2f}) With Coefficients and Probabilities",
-                                labels=dict(
-                                    zip(range(len(df.columns)), df.columns)
-                                ),
+                                labels=dict(zip(range(len(df.columns)), df.columns)),
                                 show=show_plot,
                                 output_path=os.path.join(
                                     out_sem_dir,
@@ -816,7 +817,7 @@ class CausalPipe:
                         "n_samples",
                         "comparison_results",
                         "is_better_model",
-                        "model_2_string"
+                        "model_2_string",
                     ]
                     sem_results_to_dump = {
                         k: v for k, v in sem_results.items() if k in keys_to_extract

--- a/causal_pipe/pipe_config.py
+++ b/causal_pipe/pipe_config.py
@@ -143,6 +143,7 @@ class SkeletonMethod(BaseModel):
     params: Optional[Dict[str, Any]] = Field(default_factory=dict)
     bootstrap_resamples: int = 0
     bootstrap_random_state: Optional[int] = None
+    bootstrap_edge_threshold: Optional[float] = None
 
     @field_validator("alpha")
     @classmethod
@@ -158,6 +159,12 @@ class SkeletonMethod(BaseModel):
             raise ValueError("bootstrap_resamples must be non-negative")
         return v
 
+    @field_validator("bootstrap_edge_threshold")
+    @classmethod
+    def check_bootstrap_edge_threshold(cls, v):
+        if v is not None and not (0.0 <= v <= 1.0):
+            raise ValueError("bootstrap_edge_threshold must be between 0.0 and 1.0")
+        return v
 
     class Config:
         validate_assignment = True
@@ -285,7 +292,9 @@ class HillClimbingOrientationMethod(OrientationMethod):
     @classmethod
     def warn_bootstrap_not_supported(cls, v):
         if v > 0:
-            print("Warning: bootstrap_resamples is not supported for Hill Climbing and will be ignored.")
+            print(
+                "Warning: bootstrap_resamples is not supported for Hill Climbing and will be ignored."
+            )
         return v
 
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -198,10 +198,12 @@ Retrieves the names of ordinal and nominal variables.
     - `params` (`Optional[Dict[str, Any]]`, default `{}`): Additional parameters.
     - `bootstrap_resamples` (`int`, default `0`): Number of bootstrap resamples for skeleton stability estimation. Must be non-negative.
     - `bootstrap_random_state` (`Optional[int]`, default `None`): Seed for the skeleton bootstrap resampling procedure.
+    - `bootstrap_edge_threshold` (`Optional[float]`, default `None`): If set, edges in the best bootstrap graph with probability below this threshold are removed. Must be between `0.0` and `1.0`.
 
 - **Validations:**
     - `alpha` must be between `0.0` and `1.0`.
     - `bootstrap_resamples` must be non-negative.
+    - `bootstrap_edge_threshold` must be between `0.0` and `1.0`.
 
 ---
 

--- a/tests/test_fas_bootstrap_threshold.py
+++ b/tests/test_fas_bootstrap_threshold.py
@@ -1,0 +1,160 @@
+import os
+import sys
+import types
+import pandas as pd
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(ROOT)
+causal_pipe_pkg = types.ModuleType("causal_pipe")
+causal_pipe_pkg.__path__ = [os.path.join(ROOT, "causal_pipe")]
+sys.modules.setdefault("causal_pipe", causal_pipe_pkg)
+
+causal_pipe_cd_pkg = types.ModuleType("causal_pipe.causal_discovery")
+causal_pipe_cd_pkg.__path__ = [os.path.join(ROOT, "causal_pipe", "causal_discovery")]
+sys.modules.setdefault("causal_pipe.causal_discovery", causal_pipe_cd_pkg)
+static_causal_discovery = types.ModuleType(
+    "causal_pipe.causal_discovery.static_causal_discovery"
+)
+static_causal_discovery.visualize_graph = lambda *args, **kwargs: None
+sys.modules.setdefault(
+    "causal_pipe.causal_discovery.static_causal_discovery", static_causal_discovery
+)
+setattr(causal_pipe_pkg, "causal_discovery", causal_pipe_cd_pkg)
+setattr(causal_pipe_cd_pkg, "static_causal_discovery", static_causal_discovery)
+
+# Create minimal stub modules for causallearn
+causallearn = types.ModuleType("causallearn")
+causallearn_utils = types.ModuleType("causallearn.utils")
+causallearn_utils_cit = types.ModuleType("causallearn.utils.cit")
+causallearn_utils_FAS = types.ModuleType("causallearn.utils.FAS")
+causallearn_graph = types.ModuleType("causallearn.graph")
+causallearn_graph_GeneralGraph = types.ModuleType("causallearn.graph.GeneralGraph")
+causallearn_graph_Edge = types.ModuleType("causallearn.graph.Edge")
+causallearn_graph_Endpoint = types.ModuleType("causallearn.graph.Endpoint")
+causallearn_graph_GraphNode = types.ModuleType("causallearn.graph.GraphNode")
+causallearn_graph_NodeType = types.ModuleType("causallearn.graph.NodeType")
+bcsl_graph_utils = types.ModuleType("bcsl.graph_utils")
+pydot = types.ModuleType("pydot")
+
+
+class _DummyGraph:
+    def __init__(self, edges):
+        self._edges = edges
+
+    def get_graph_edges(self):
+        return self._edges
+
+    def get_nodes(self):
+        return []
+
+
+causallearn_graph_GeneralGraph.GeneralGraph = _DummyGraph
+causallearn_graph_Edge.Edge = type("Edge", (), {})
+causallearn_graph_Endpoint.Endpoint = type("Endpoint", (), {})
+
+
+class GraphNode:
+    def __init__(self, name):
+        self._name = name
+
+    def get_name(self):
+        return self._name
+
+
+causallearn_graph_GraphNode.GraphNode = GraphNode
+causallearn_graph_NodeType.NodeType = type("NodeType", (), {})
+
+bcsl_graph_utils.get_nondirected_edge = lambda *args, **kwargs: None
+bcsl_graph_utils.get_undirected_edge = lambda *args, **kwargs: None
+bcsl_graph_utils.get_directed_edge = lambda *args, **kwargs: None
+bcsl_graph_utils.get_bidirected_edge = lambda *args, **kwargs: None
+pydot.Dot = type("Dot", (), {})
+pydot.Node = type("Node", (), {})
+pydot.Edge = type("Edge", (), {})
+
+
+class _DummyCIT:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+causallearn_utils_cit.CIT = _DummyCIT
+
+# placeholder fas function
+causallearn_utils_FAS.fas = lambda *args, **kwargs: None
+
+# register stub modules
+sys.modules.setdefault("causallearn", causallearn)
+sys.modules.setdefault("causallearn.utils", causallearn_utils)
+sys.modules.setdefault("causallearn.utils.cit", causallearn_utils_cit)
+sys.modules.setdefault("causallearn.utils.FAS", causallearn_utils_FAS)
+sys.modules.setdefault("causallearn.graph", causallearn_graph)
+sys.modules.setdefault("causallearn.graph.GeneralGraph", causallearn_graph_GeneralGraph)
+sys.modules.setdefault("causallearn.graph.Edge", causallearn_graph_Edge)
+sys.modules.setdefault("causallearn.graph.Endpoint", causallearn_graph_Endpoint)
+sys.modules.setdefault("causallearn.graph.GraphNode", causallearn_graph_GraphNode)
+sys.modules.setdefault("causallearn.graph.NodeType", causallearn_graph_NodeType)
+sys.modules.setdefault("bcsl.graph_utils", bcsl_graph_utils)
+sys.modules.setdefault("pydot", pydot)
+
+from causal_pipe.causal_discovery.fas_bootstrap import bootstrap_fas_edge_stability
+
+
+def test_fas_bootstrap_filters_edges_below_threshold(monkeypatch):
+    class MockNode:
+        def __init__(self, name):
+            self._name = name
+
+        def get_name(self):
+            return self._name
+
+    class MockEdge:
+        def __init__(self, n1, n2):
+            self._n1 = n1
+            self._n2 = n2
+
+        def get_node1(self):
+            return self._n1
+
+        def get_node2(self):
+            return self._n2
+
+    class MockGraph(_DummyGraph):
+        pass
+
+    data = pd.DataFrame({"A": [0, 1, 2], "B": [0, 1, 2], "C": [0, 1, 2]})
+
+    A, B, C = MockNode("A"), MockNode("B"), MockNode("C")
+    g1 = MockGraph([MockEdge(A, B)])
+    g2 = MockGraph([MockEdge(A, B), MockEdge(B, C)])
+
+    graphs = iter([g2, g2, g1])
+
+    def fas_mock(*args, **kwargs):
+        return next(graphs), {}, None
+
+    monkeypatch.setattr("causal_pipe.causal_discovery.fas_bootstrap.fas", fas_mock)
+
+    def make_graph_mock(node_names, edges_repr):
+        node_map = {name: MockNode(name) for name in node_names}
+        edges = [MockEdge(node_map[a], node_map[b]) for a, b, *_ in edges_repr]
+        return MockGraph(edges)
+
+    monkeypatch.setattr(
+        "causal_pipe.causal_discovery.fas_bootstrap.make_graph", make_graph_mock
+    )
+
+    probs, best_graph = bootstrap_fas_edge_stability(
+        data, resamples=3, random_state=0, edge_threshold=0.8
+    )
+
+    assert probs[("A", "B")] == 1.0
+    assert pytest.approx(probs[("B", "C")], 0.01) == 2 / 3
+    assert best_graph is not None
+    _, graph_obj, _, _ = best_graph
+    edges = [
+        (e.get_node1().get_name(), e.get_node2().get_name())
+        for e in graph_obj.get_graph_edges()
+    ]
+    assert edges == [("A", "B")]


### PR DESCRIPTION
## Summary
- allow `bootstrap_fas_edge_stability` to drop edges whose bootstrap probability is below a given threshold
- expose new `bootstrap_edge_threshold` option on skeleton config and wire through pipeline
- document new option and cover it with a unit test

## Testing
- `pytest tests/test_fas_bootstrap_threshold.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68bd0312c0fc833086c9a04991ee36e7