### PR TITLE
feat: orient edges and derive structural equations with PySR

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - **Data Preprocessing:** Handle missing values using multiple imputation (`MICE`), encode categorical variables, standardize features, and perform feature selection based on correlation.
 - **Skeleton Identification:** Identify the global skeleton of the causal graph using methods like Fast Adjacency Search (`FAS`) or Bootstrap-based Causal Structure Learning (`BCSL`).
 - **Edge Orientation:** Orient edges in the skeleton using algorithms such as Fast Causal Inference (`FCI`) or Hill Climbing.
-- **Causal Effect Estimation:** Estimate causal effects using various methods, including Partial Pearson Correlation, Partial Spearman Correlation, Conditional Mutual Information (`MI`), Kernel Conditional Independence (`KCI`), Structural Equation Modeling (`SEM`), and Hill Climbing-based SEM.
+- **Causal Effect Estimation:** Estimate causal effects using various methods, including Partial Pearson Correlation, Partial Spearman Correlation, Conditional Mutual Information (`MI`), Kernel Conditional Independence (`KCI`), Structural Equation Modeling (`SEM`), Hill Climbing-based SEM, and PySR-based symbolic regression that infers structural equations and can optionally orient remaining undirected edges via SEM hill climbing or treat them as exogenous parents.
 - **Visualization:** Generate and save visualizations for correlation graphs, skeletons, oriented graphs, and SEM results.
 - **Modular Configuration:** Easily configure different aspects of the pipeline through dataclasses, allowing for flexible and customizable causal discovery workflows.
 - **Integration with R:** Utilize R's `lavaan` package for advanced Structural Equation Modeling directly within Python using `rpy2`.

--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -745,23 +745,6 @@ class CausalPipe:
                     hc_orient = pysr_params.pop("hc_orient_undirected_edges", True)
                     pysr_params["output_directory"] = os.path.join(out_dir, "pysr_output")
                     pysr_params["random_state"] = self.seed
-                    binary_operators=[
-                        "+", "*", "-", "/","^",
-                          # "mod", "min",
-                          # "max", ">", "<",
-                          # "logical_or", "logical_and"
-                    ]
-                    unary_operators=[
-                        # "cos",
-                        # "tan",
-                        "exp",
-                        # "sin",
-                        "sqrt",
-                        "log",
-                        "cube"
-                    ]
-                    pysr_params["binary_operators"] = pysr_params.get("binary_operators", binary_operators)
-                    pysr_params["unary_operators"] = pysr_params.get("unary_operators", unary_operators)
                     self.causal_effects[method.name] = symbolic_regression_causal_effect(
                         df,
                         graph,

--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -32,7 +32,7 @@ from causal_pipe.utilities.graph_utilities import (
     general_graph_to_sem_model,
     get_nodes_from_node_names,
     add_edge_coefficients_from_sem_fit,
-    add_edge_probabilities_to_graph,
+    add_edge_probabilities_to_graph, add_psyr_structural_equation_to_edge_coefficients,
 )
 from causal_pipe.utilities.plot_utilities import plot_correlation_graph
 from causal_pipe.pysr_regression import symbolic_regression_causal_effect
@@ -756,13 +756,25 @@ class CausalPipe:
                         data=self.causal_effects[method.name],
                         path=os.path.join(out_dir, f"{method.name}_results.json"),
                     )
-                    graph = graph_with_pysr_scm(
-                        self.causal_effects[method.name],
+                    # graph = graph_with_pysr_scm(
+                    #     self.causal_effects[method.name],
+                    #     title="PySR SCM Result",
+                    #     show=show_plot,
+                    #     output_path=os.path.join(out_dir, "pysr_scm.png"),
+                    # )
+                    coef_graph, edges_with_coefficients = (
+                        add_psyr_structural_equation_to_edge_coefficients(
+                            psyr_output=self.causal_effects[method.name],
+                        )
+                    )
+                    visualize_graph(
+                        coef_graph,
+                        edges=edges_with_coefficients,
                         title="PySR SCM Result",
                         show=show_plot,
-                        output_path=os.path.join(out_dir, "pysr_scm.png"),
+                        output_path=os.path.join(out_dir, "pysr_scm_with_equations.png")
                     )
-                else:
+            else:
                     raise ValueError(
                         f"Unsupported causal effect estimation method: {method.name}"
                     )

--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -391,6 +391,7 @@ class CausalPipe:
                         fas_kwargs=fas_kwargs,
                         output_dir=os.path.join(self.output_path, "fas_bootstrap"),
                         edge_threshold=self.skeleton_method.bootstrap_edge_threshold,
+                        n_jobs=self.skeleton_method.n_jobs,
                     )
                     if self.best_graph_with_fas_bootstrap:
                         prob, best_graph_bootstrap, edge_probs, sepsets_bootstrap = (

--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -45,6 +45,7 @@ from .pipe_config import (
     VariableTypes, CausalEffectMethodNameEnum,
 )
 from .utilities.utilities import dump_json_to, set_seed_python_and_r
+from .utilities.visualize_pysr_scm import graph_with_pysr_scm
 
 
 class CausalPipe:
@@ -754,6 +755,12 @@ class CausalPipe:
                     dump_json_to(
                         data=self.causal_effects[method.name],
                         path=os.path.join(out_dir, f"{method.name}_results.json"),
+                    )
+                    graph = graph_with_pysr_scm(
+                        self.causal_effects[method.name],
+                        title="PySR SCM Result",
+                        show=show_plot,
+                        output_path=os.path.join(out_dir, "pysr_scm.png"),
                     )
                 else:
                     raise ValueError(

--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -774,10 +774,10 @@ class CausalPipe:
                         show=show_plot,
                         output_path=os.path.join(out_dir, "pysr_scm_with_equations.png")
                     )
-            else:
-                    raise ValueError(
-                        f"Unsupported causal effect estimation method: {method.name}"
-                    )
+                else:
+                        raise ValueError(
+                            f"Unsupported causal effect estimation method: {method.name}"
+                        )
 
             print("Causal effect estimation completed.")
             return self.causal_effects

--- a/causal_pipe/pipe_config.py
+++ b/causal_pipe/pipe_config.py
@@ -144,6 +144,7 @@ class SkeletonMethod(BaseModel):
     bootstrap_resamples: int = 0
     bootstrap_random_state: Optional[int] = None
     bootstrap_edge_threshold: Optional[float] = None
+    n_jobs: Optional[int] = None
 
     @field_validator("alpha")
     @classmethod

--- a/causal_pipe/pipe_config.py
+++ b/causal_pipe/pipe_config.py
@@ -68,6 +68,7 @@ class CausalEffectMethodNameEnum(str, Enum):
     KCI = "kci"
     SEM = "sem"
     SEM_CLIMBING = "sem-climbing"
+    PYSR = "pysr"
 
 
 # Pydantic Models with Validations

--- a/causal_pipe/pysr_regression.py
+++ b/causal_pipe/pysr_regression.py
@@ -1,0 +1,203 @@
+import json
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+
+from causallearn.graph.GeneralGraph import GeneralGraph
+
+from .partial_correlations.partial_correlations import get_parents_or_undirected
+from .sem.sem import search_best_graph_climber
+
+
+def _fit_pysr(X: np.ndarray, y: np.ndarray, params: Dict) -> Tuple[str, float]:
+    """Fit a PySR symbolic regression model and return equation string and R^2."""
+    try:
+        from pysr import PySRRegressor
+    except ImportError as exc:
+        raise ImportError("PySR is required for symbolic regression causal effect estimation") from exc
+
+    # Ensure X has at least one column
+    if X.ndim == 1:
+        X = X.reshape(-1, 1)
+    if X.shape[1] == 0:
+        # Use a constant column when no predictors are provided
+        X = np.ones((len(X), 1))
+
+    model = PySRRegressor(**params)
+    model.fit(X, y)
+    try:
+        equation = str(model.get_best()['repr'])
+    except Exception:
+        # Fallback if get_best is not available
+        equation = str(model)
+    y_hat = model.predict(X)
+    r2 = 1 - np.sum((y - y_hat) ** 2) / np.sum((y - np.mean(y)) ** 2)
+    return equation, float(r2)
+
+
+def symbolic_regression_causal_effect(
+    df: pd.DataFrame,
+    graph: GeneralGraph,
+    pysr_params: Dict | None = None,
+    hc_orient_undirected_edges: bool = True,
+) -> Dict:
+    """Estimate causal mechanisms using symbolic regression via PySR.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Preprocessed data.
+    graph : GeneralGraph
+        Graph containing directed and undirected edges.
+    pysr_params : dict, optional
+        Parameters for :class:`pysr.PySRRegressor`.
+    hc_orient_undirected_edges : bool, optional
+        When ``True`` (default), attempt to orient undirected edges using
+        SEM hill climbing before running PySR. When ``False``, undirected
+        edges are treated as parents for both incident nodes and no
+        orientation tests are performed.
+
+    Returns
+    -------
+    dict
+        Dictionary containing equations for each node and orientation tests
+        for edges that were not oriented in ``graph``.
+    """
+    if pysr_params is None:
+        pysr_params = {}
+
+    default_params = {
+        # Broad search space similar to PySR defaults
+        "niterations": 200,
+        "population_size": 200,
+        "binary_operators": ["+", "-", "*", "/", "pow"],
+        "unary_operators": ["exp", "log", "sin", "cos", "sqrt"],
+        "maxsize": 20,
+        "maxdepth": 5,
+    }
+    params = {**default_params, **pysr_params}
+
+    node_names = list(df.columns)
+
+    if hc_orient_undirected_edges:
+        # Attempt to orient edges via hill climbing prior to PySR fits
+        try:
+            graph, _ = search_best_graph_climber(
+                data=df,
+                initial_graph=graph,
+                node_names=node_names,
+                respect_pag=True,
+            )
+        except Exception:
+            # If hill climbing fails, continue with original graph
+            pass
+
+        edge_tests: Dict[str, Dict] = {}
+
+        n_nodes = len(node_names)
+        for i in range(n_nodes):
+            target = node_names[i]
+            predictors, pred_indices = get_parents_or_undirected(graph, i)
+            if not pred_indices:
+                continue
+
+            y = df.iloc[:, i].values
+
+            # Evaluate each predictor for orientation suggestions
+            for p_idx in pred_indices:
+                if p_idx <= i:
+                    # Avoid duplicate testing of undirected edges
+                    continue
+                p_name = node_names[p_idx]
+                if graph.is_directed_from_to(graph.nodes[p_idx], graph.nodes[i]):
+                    # Already oriented p -> target; no need for test
+                    continue
+                if graph.is_directed_from_to(graph.nodes[i], graph.nodes[p_idx]):
+                    # target -> p; skip since p is child
+                    continue
+
+                with_idx = pred_indices
+                without_idx = [idx for idx in pred_indices if idx != p_idx]
+
+                X_with = df.iloc[:, with_idx].values
+                _, r2_with = _fit_pysr(X_with, y, params)
+
+                if without_idx:
+                    X_without = df.iloc[:, without_idx].values
+                else:
+                    X_without = np.empty((len(df), 0))
+                _, r2_without = _fit_pysr(X_without, y, params)
+                improvement_target = r2_with - r2_without
+
+                # Symmetric test: predictor as target
+                ppredictors, ppred_indices = get_parents_or_undirected(graph, p_idx)
+                if i not in ppred_indices:
+                    ppred_indices.append(i)
+                yp = df.iloc[:, p_idx].values
+                Xp_with = df.iloc[:, ppred_indices].values
+                _, r2p_with = _fit_pysr(Xp_with, yp, params)
+                ppred_without = [idx for idx in ppred_indices if idx != i]
+                if ppred_without:
+                    Xp_without = df.iloc[:, ppred_without].values
+                else:
+                    Xp_without = np.empty((len(df), 0))
+                _, r2p_without = _fit_pysr(Xp_without, yp, params)
+                improvement_pred = r2p_with - r2p_without
+
+                orientation = (
+                    f"{p_name} -> {target}"
+                    if improvement_target >= improvement_pred
+                    else f"{target} -> {p_name}"
+                )
+                edge_tests[f"{p_name}--{target}"] = {
+                    "improvement_parent_to_child": improvement_target,
+                    "improvement_child_to_parent": improvement_pred,
+                    "suggested_orientation": orientation,
+                }
+
+        # Determine final parent sets based on orientation suggestions
+        parent_indices: Dict[str, List[int]] = {name: [] for name in node_names}
+        for i, name in enumerate(node_names):
+            # include existing directed parents from graph
+            for parent in graph.get_parents(graph.nodes[i]):
+                parent_indices[name].append(graph.node_map[parent])
+
+        for info in edge_tests.values():
+            src, dst = info["suggested_orientation"].split(" -> ")
+            dst_idxs = parent_indices[dst]
+            src_idx = node_names.index(src)
+            if src_idx not in dst_idxs:
+                dst_idxs.append(src_idx)
+
+        structural_equations: Dict[str, Dict] = {}
+        for name, pidxs in parent_indices.items():
+            X = df.iloc[:, pidxs].values if pidxs else np.empty((len(df), 0))
+            y = df[name].values
+            equation, r2 = _fit_pysr(X, y, params)
+            structural_equations[name] = {
+                "equation": equation,
+                "r2": r2,
+                "parents": [node_names[idx] for idx in pidxs],
+            }
+
+        return {"edge_tests": edge_tests, "structural_equations": structural_equations}
+
+    # When hill climbing orientation is disabled, treat undirected neighbors as parents
+    parent_indices: Dict[str, List[int]] = {name: [] for name in node_names}
+    for i, name in enumerate(node_names):
+        _, pred_indices = get_parents_or_undirected(graph, i)
+        parent_indices[name] = pred_indices
+
+    structural_equations: Dict[str, Dict] = {}
+    for name, pidxs in parent_indices.items():
+        X = df.iloc[:, pidxs].values if pidxs else np.empty((len(df), 0))
+        y = df[name].values
+        equation, r2 = _fit_pysr(X, y, params)
+        structural_equations[name] = {
+            "equation": equation,
+            "r2": r2,
+            "parents": [node_names[idx] for idx in pidxs],
+        }
+
+    return {"edge_tests": {}, "structural_equations": structural_equations}

--- a/causal_pipe/utilities/graph_utilities.py
+++ b/causal_pipe/utilities/graph_utilities.py
@@ -796,6 +796,24 @@ def add_edge_coefficients_from_sem_fit(
     return coef_graph, edges_with_coefficients
 
 
+def add_psyr_structural_equation_to_edge_coefficients(
+    psyr_output: Dict[str, Any],
+) -> Tuple[GeneralGraph, List[Edge]]:
+    """Extract coefficients from PySR structural equations."""
+    final_graph = psyr_output.get("final_graph")
+    if final_graph is None:
+        raise ValueError("No final_graph in psyr_output.")
+    structural_equations = psyr_output.get("structural_equations", {})
+    if not structural_equations:
+        raise ValueError("No structural_equations in psyr_output.")
+
+    # TODO
+    coef_graph = copy_graph(final_graph)
+    edges_with_coefficients: List[Edge] = []
+
+    return coef_graph, edges_with_coefficients
+
+
 class EdgeWithCoefficient(Edge):
     def __init__(
         self,

--- a/causal_pipe/utilities/graph_utilities.py
+++ b/causal_pipe/utilities/graph_utilities.py
@@ -1003,7 +1003,10 @@ def graph_with_coefficient_to_pydot(
             coefficient = edge.coefficient
             probability = getattr(edge, "probability", None)
             if coefficient is not None:
-                parts.append(f"{coefficient:.3f}")
+                try:
+                    parts.append(f"{coefficient:.3f}")
+                except (ValueError, TypeError):
+                    parts.append(str(coefficient))
                 if coefficient > 0:
                     color = POSITIVE_COLOR
                 elif coefficient < 0:

--- a/causal_pipe/utilities/graph_utilities.py
+++ b/causal_pipe/utilities/graph_utilities.py
@@ -1005,12 +1005,14 @@ def graph_with_coefficient_to_pydot(
             if coefficient is not None:
                 try:
                     parts.append(f"{coefficient:.3f}")
+                    if coefficient > 0:
+                        color = POSITIVE_COLOR
+                    elif coefficient < 0:
+                        color = NEGATIVE_COLOR
                 except (ValueError, TypeError):
                     parts.append(str(coefficient))
-                if coefficient > 0:
-                    color = POSITIVE_COLOR
-                elif coefficient < 0:
-                    color = NEGATIVE_COLOR
+                    color = "black"
+
             if probability is not None:
                 prob_pct = probability * 100
                 if parts:

--- a/causal_pipe/utilities/graph_utilities.py
+++ b/causal_pipe/utilities/graph_utilities.py
@@ -807,9 +807,25 @@ def add_psyr_structural_equation_to_edge_coefficients(
     if not structural_equations:
         raise ValueError("No structural_equations in psyr_output.")
 
-    # TODO
     coef_graph = copy_graph(final_graph)
     edges_with_coefficients: List[Edge] = []
+    added_equation_to_node = {}
+    for edge in final_graph.get_graph_edges():
+        n1 = edge.get_node1()
+        n2 = edge.get_node2()
+        endpoint_1 = edge.endpoint1
+        endpoint_2 = edge.endpoint2
+        equation = structural_equations.get(n2.get_name()).get("equation")
+        if equation is None or n2.get_name() in added_equation_to_node:
+            edges_with_coefficients.append(edge)
+            continue
+        added_equation_to_node[n2.get_name()] = True
+        edge_coef = EdgeWithCoefficient(
+            n1, n2, endpoint_1, endpoint_2, coefficient=equation
+        )
+        coef_graph.remove_edge(edge)
+        coef_graph.add_edge(edge_coef)
+        edges_with_coefficients.append(edge_coef)
 
     return coef_graph, edges_with_coefficients
 

--- a/causal_pipe/utilities/visualize_pysr_scm.py
+++ b/causal_pipe/utilities/visualize_pysr_scm.py
@@ -1,0 +1,76 @@
+from typing import Dict, Any
+
+import pydot
+
+def graph_with_pysr_scm(pysr_results: Dict[str, Any],
+                       show: bool = True,
+                       title=None,
+                       output_path=None,
+                       labels=None
+                       ) -> pydot.Dot:
+    """
+    Visualize the structural causal model (SCM) derived from PySR results using NetworkX and Matplotlib.
+
+    :param pysr_results:
+    :param show:
+    :param title:
+    :param output_path:
+    :param labels:
+    :return:
+    """
+
+    graph = pysr_results.get("final_graph", None)
+    if graph is None:
+        raise ValueError("No final graph found in PySR results.")
+
+    scm = pysr_results.get("structural_equations", {})
+    if not scm:
+        raise ValueError("No structural equations found in PySR results.")
+
+    G = pydot.Dot(title if title else "SCM from PySR", graph_type="digraph", fontsize=18)
+    G.obj_dict["attributes"]["dpi"] = 300
+
+    #     structural_equations[target_name] = {
+    #             "equation": best["sympy_format"] if "sympy_format" in best else str(best),
+    #             "best": best,
+    #             "r2": r2,
+    #             "parents": pnames,
+    #         }
+    nodes = list(scm.keys())
+    if labels is not None:
+        assert len(labels) == len(nodes), "Length of labels must match number of nodes."
+
+    # Add nodes to the pydot graph
+    for i, node in enumerate(nodes):
+        node_label = labels[i] if labels is not None else node
+        pydot_node = pydot.Node(str(i), label=node_label, shape="ellipse")
+        G.add_node(pydot_node)
+
+    node_to_id = {node: i for i, node in enumerate(nodes)}
+    # Add edges based on structural equations
+    for target, details in scm.items():
+        target_id = node_to_id[target]
+        parents = details.get("parents", [])
+        for parent in parents:
+            if parent not in node_to_id:
+                continue
+            parent_id = node_to_id[parent]
+            edge = pydot.Edge(str(parent_id), str(target_id), arrowhead="normal", dir="forward")
+            edge_equation = details.get("equation", "")
+            r2 = details.get("r2", None)
+            label_parts = []
+            if edge_equation:
+                label_parts.append(edge_equation)
+            if r2 is not None:
+                label_parts.append(f"R²={r2:.2f}")
+            if label_parts:
+                edge.set_label("\n".join(label_parts))
+                edge.set_fontsize("10")
+            G.add_edge(edge)
+
+    if output_path is not None:
+        G.write_png(output_path)
+        print(f"SCM graph saved to {output_path}")
+
+    return G
+

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -869,6 +869,10 @@ class CausalEffectMethod(BaseModel):
         directed (bool): True if the method starts from the directed graph,
                         False if it will use the undirected graph (Markov Blanket / General Skeleton).
         params (Optional[Dict[str, Any]]): Additional parameters for the method.
+            - For `'pysr'`, accepts ``hc_orient_undirected_edges`` (`bool`, default
+              ``True``) to attempt hill-climbing orientation of undirected edges
+              before fitting PySR; when ``False`` undirected neighbors are
+              treated as parents.
     """
 
     name: CausalEffectMethodNameEnum = CausalEffectMethodNameEnum.PEARSON
@@ -956,4 +960,4 @@ class CausalPipeConfig(BaseModel):
   - `"Hill Climbing"`: Hill Climbing Algorithm.
 
 - **`CausalEffectMethodNameEnum`**: Names of methods for estimating causal effects.
-  - `'pearson'`, `'spearman'`, `'mi'`, `'kci'`, `'sem'`, `'sem-climbing'`.
+  - `'pearson'`, `'spearman'`, `'mi'`, `'kci'`, `'sem'`, `'sem-climbing'`, `'pysr'`.

--- a/examples/easy.py
+++ b/examples/easy.py
@@ -14,6 +14,7 @@ from examples.utilities import compare_pipelines
 def compare_easy_dataset(config: CausalPipeConfig):
     # Generate synthetic data for testing
     np.random.seed(config.seed)
+    config.study_name = "pipe_easy_dataset"
 
     # Define True Causal Graph
     true_graph = create_true_causal_graph_easy()

--- a/examples/super_basic.py
+++ b/examples/super_basic.py
@@ -19,6 +19,7 @@ def compare_super_basic_dataset(config: CausalPipeConfig):
     """
     # Reproducibility
     np.random.seed(config.seed)
+    config.study_name = "pipe_super_basic_dataset"
 
     # True graph
     true_graph = create_true_causal_graph_super_basic()

--- a/examples/super_basic.py
+++ b/examples/super_basic.py
@@ -1,0 +1,57 @@
+import numpy as np
+import pandas as pd
+from bcsl.graph_utils import visualize_graph
+from causallearn.graph.Edge import Edge
+from causallearn.graph.Endpoint import Endpoint
+from causallearn.graph.GeneralGraph import GeneralGraph
+from causallearn.graph.GraphNode import GraphNode
+
+from causal_pipe.causal_pipe import CausalPipeConfig
+from causal_pipe.pipe_config import VariableTypes
+from examples.utilities import compare_pipelines
+
+
+def compare_super_basic_dataset(config: CausalPipeConfig):
+    """
+    Super-basic 2-node simulation: Var0 -> Var1
+    Var0 ~ N(0,1)
+    Var1 = 2*Var0 + eps, eps ~ N(0,1)
+    """
+    # Reproducibility
+    np.random.seed(config.seed)
+
+    # True graph
+    true_graph = create_true_causal_graph_super_basic()
+    visualize_graph(true_graph, title="True Causal Graph (SUPER BASIC: Var0 → Var1)", show=True)
+
+    # Generate data
+    n_samples = 500
+    Var0 = np.random.normal(0, 1, n_samples)
+    Var1 = 2 * Var0 + np.random.normal(0, 1, n_samples)
+
+    data = pd.DataFrame({"Var0": Var0, "Var1": Var1})
+
+    # Variable types
+    config.variable_types = VariableTypes(continuous=["Var0", "Var1"])
+
+    # Run your comparison
+    compare_pipelines(data, config=config)
+
+
+def create_true_causal_graph_super_basic() -> GeneralGraph:
+    """
+    Creates the true 2-node causal graph: Var0 -> Var1.
+    """
+    node_names = ["Var0", "Var1"]
+    nodes = {name: GraphNode(name) for name in node_names}
+    graph = GeneralGraph(list(nodes.values()))
+
+    edge = Edge(
+        nodes["Var0"],
+        nodes["Var1"],
+        Endpoint.TAIL,   # source
+        Endpoint.ARROW,  # target
+    )
+    graph.add_edge(edge)
+
+    return graph

--- a/main.py
+++ b/main.py
@@ -32,7 +32,10 @@ if __name__ == "__main__":
     config = CausalPipeConfig(
         variable_types=VariableTypes(continuous=[], ordinal=[], nominal=[]),
         preprocessing_params=preprocessor_params,
-        skeleton_method=FASSkeletonMethod(bootstrap_resamples=50),
+        skeleton_method=FASSkeletonMethod(
+            bootstrap_resamples=500,
+            # n_jobs=4 or None if you want to use (all available cores - 1)
+        ),
         orientation_method=FCIOrientationMethod(),
         causal_effect_methods=[
             # Best method - Respect FCI Edge Directions - No Climbing

--- a/main.py
+++ b/main.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
         show_plots=False,
         verbose=True,
     )
-    compare_super_basic_dataset(config)
-    # compare_easy_dataset(config)
+    # compare_super_basic_dataset(config)
+    compare_easy_dataset(config)
     # compare_easy_dataset_with_ordinal(config)
     # compare_hard_dataset(config)

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         variable_types=VariableTypes(continuous=[], ordinal=[], nominal=[]),
         preprocessing_params=preprocessor_params,
         skeleton_method=FASSkeletonMethod(
-            bootstrap_resamples=500,
+            bootstrap_resamples=50,
             # n_jobs=4 or None if you want to use (all available cores - 1)
         ),
         orientation_method=FCIOrientationMethod(),

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from causal_pipe.causal_pipe import (
 from causal_pipe.pipe_config import (
     VariableTypes,
     DataPreprocessingParams,
-    CausalEffectMethod,
+    CausalEffectMethod, CausalEffectMethodNameEnum,
 )
 from examples.easy import compare_easy_dataset
 from examples.easy_ordinal import compare_easy_dataset_with_ordinal
@@ -39,23 +39,29 @@ if __name__ == "__main__":
         orientation_method=FCIOrientationMethod(),
         causal_effect_methods=[
             # Best method - Respect FCI Edge Directions - No Climbing
-            CausalEffectMethod(name="sem", directed=True, params={"estimator": "MLR"}),
+            CausalEffectMethod(name=CausalEffectMethodNameEnum.SEM, directed=True, params={"estimator": "MLR"}),
             # For ordinal data
             # CausalEffectMethod(
             #     name="sem", directed=True, params={"estimator": "WLSMV"}
             # ),
             # Simple pearson/spearman partial correlation
-            CausalEffectMethod(name="pearson", directed=True),
+            CausalEffectMethod(name=CausalEffectMethodNameEnum.PEARSON, directed=True),
             # CausalEffectMethod(name="spearman", directed=True),
             # SEM Climbing, only ML based estimators are supported
-            CausalEffectMethod(
-                name="sem-climbing", directed=True, params={"estimator": "ML",
-                                                            "respect_pag": True,
-                                                            "finalize_with_resid_covariances": True}
-            ),
+            # CausalEffectMethod(
+            #     name="sem-climbing", directed=True, params={"estimator": "ML",
+            #                                                 "respect_pag": True,
+            #                                                 "finalize_with_resid_covariances": True}
+            # ),
             # CausalEffectMethod(
             #     name="sem-climbing", directed=True, params={"estimator": "MLR"}
             # ),
+            # PySR-based Causal Effect estimation
+            CausalEffectMethod(
+                name=CausalEffectMethodNameEnum.PYSR,
+                directed=True,
+                params={"hc_orient_undirected_edges": False},
+            ),
         ],
         study_name="pipe_easy_dataset",
         output_path="./output/",
@@ -63,5 +69,5 @@ if __name__ == "__main__":
         verbose=True,
     )
     compare_easy_dataset(config)
-    compare_easy_dataset_with_ordinal(config)
-    compare_hard_dataset(config)
+    # compare_easy_dataset_with_ordinal(config)
+    # compare_hard_dataset(config)

--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
                 params={"hc_orient_undirected_edges": False},
             ),
         ],
-        study_name="pipe_easy_dataset",
+        study_name="pipe_super_basic_dataset",
         output_path="./output/",
         show_plots=False,
         verbose=True,

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from causal_pipe.pipe_config import (
 from examples.easy import compare_easy_dataset
 from examples.easy_ordinal import compare_easy_dataset_with_ordinal
 from examples.hard import compare_hard_dataset
+from examples.super_basic import compare_super_basic_dataset
 
 if __name__ == "__main__":
     """
@@ -68,6 +69,7 @@ if __name__ == "__main__":
         show_plots=False,
         verbose=True,
     )
-    compare_easy_dataset(config)
+    compare_super_basic_dataset(config)
+    # compare_easy_dataset(config)
     # compare_easy_dataset_with_ordinal(config)
     # compare_hard_dataset(config)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="causal-pipe",
-    version="0.9.9",
+    version="0.9.10",
     author="Buchard, Albert",
     author_email="albert.buchard@gmail.com",
     description="A Python package streamlining the causal discovery pipeline for easy use.",

--- a/tests/test_bootstrap_edge_stability.py
+++ b/tests/test_bootstrap_edge_stability.py
@@ -69,9 +69,23 @@ class GeneralGraph:
     def __init__(self, nodes):
         self._nodes = nodes
         self._edges = []
+        self.node_map = {node: i for i, node in enumerate(nodes)}
 
     def add_edge(self, edge):
-        self._edges.append(edge)
+        if edge is not None:
+            self._edges.append(edge)
+
+    def add_directed_edge(self, n1, n2):
+        self.add_edge(Edge(n1, n2, Endpoint.TAIL, Endpoint.ARROW))
+
+    def remove_edge(self, edge):
+        if edge in self._edges:
+            self._edges.remove(edge)
+
+    def remove_connecting_edge(self, n1, n2):
+        edge = self.get_edge(n1, n2)
+        if edge in self._edges:
+            self._edges.remove(edge)
 
     def get_graph_edges(self):
         return self._edges
@@ -79,19 +93,71 @@ class GeneralGraph:
     def get_nodes(self):
         return self._nodes
 
+    def get_num_nodes(self):
+        return len(self._nodes)
+
+    def get_edge(self, n1, n2):
+        for e in self._edges:
+            if e is None:
+                continue
+            if (e.node1 == n1 and e.node2 == n2) or (e.node1 == n2 and e.node2 == n1):
+                return e
+        return None
+
+    def get_node_edges(self, node):
+        return [e for e in self._edges if e.node1 == node or e.node2 == node]
+
+    def is_adjacent_to(self, n1, n2):
+        return self.get_edge(n1, n2) is not None
+
+    def is_directed_from_to(self, n1, n2):
+        e = self.get_edge(n1, n2)
+        if e is None:
+            return False
+        if e.node1 == n1 and e.endpoint1 == Endpoint.TAIL and e.endpoint2 == Endpoint.ARROW:
+            return True
+        if e.node2 == n1 and e.endpoint2 == Endpoint.TAIL and e.endpoint1 == Endpoint.ARROW:
+            return True
+        return False
+
+    def get_children(self, node):
+        children = []
+        for e in self._edges:
+            if e.node1 == node and e.endpoint1 == Endpoint.TAIL and e.endpoint2 == Endpoint.ARROW:
+                children.append(e.node2)
+            elif e.node2 == node and e.endpoint2 == Endpoint.TAIL and e.endpoint1 == Endpoint.ARROW:
+                children.append(e.node1)
+        return children
+
+    def get_parents(self, node):
+        parents = []
+        for e in self._edges:
+            if e.node1 == node and e.endpoint1 == Endpoint.ARROW and e.endpoint2 == Endpoint.TAIL:
+                parents.append(e.node2)
+            elif e.node2 == node and e.endpoint2 == Endpoint.ARROW and e.endpoint1 == Endpoint.TAIL:
+                parents.append(e.node1)
+        return parents
+
 
 class Edge:
-    def __init__(self, n1, n2, *args):
-        self._n1, self._n2 = n1, n2
+    def __init__(self, n1, n2, e1=None, e2=None):
+        self.node1, self.node2 = n1, n2
+        self.endpoint1 = e1
+        self.endpoint2 = e2
 
     def get_node1(self):
-        return self._n1
+        return self.node1
 
     def get_node2(self):
-        return self._n2
+        return self.node2
 
 
-Endpoint = {"TAIL": "TAIL", "ARROW": "ARROW"}
+class Endpoint(dict):
+    def __getattr__(self, name):
+        return self[name]
+
+
+Endpoint = Endpoint(TAIL="TAIL", ARROW="ARROW", CIRCLE="CIRCLE")
 
 causallearn_utils_cit.CIT = DummyCIT
 causallearn_utils_FAS.fas = dummy_fas
@@ -102,10 +168,22 @@ causallearn_graph_Endpoint.Endpoint = Endpoint
 causallearn_graph_NodeType.NodeType = type("NodeType", (), {})
 
 bcsl_graph_utils = types.ModuleType("bcsl.graph_utils")
-bcsl_graph_utils.get_nondirected_edge = lambda *args, **kwargs: None
-bcsl_graph_utils.get_undirected_edge = lambda *args, **kwargs: None
-bcsl_graph_utils.get_directed_edge = lambda *args, **kwargs: None
-bcsl_graph_utils.get_bidirected_edge = lambda *args, **kwargs: None
+def _undirected(n1, n2):
+    return Edge(n1, n2, Endpoint.CIRCLE, Endpoint.CIRCLE)
+
+
+def _directed(n1, n2):
+    return Edge(n1, n2, Endpoint.TAIL, Endpoint.ARROW)
+
+
+def _bidirected(n1, n2):
+    return Edge(n1, n2, Endpoint.ARROW, Endpoint.ARROW)
+
+
+bcsl_graph_utils.get_nondirected_edge = _undirected
+bcsl_graph_utils.get_undirected_edge = _undirected
+bcsl_graph_utils.get_directed_edge = _directed
+bcsl_graph_utils.get_bidirected_edge = _bidirected
 pydot = types.ModuleType("pydot")
 pydot.Dot = type("Dot", (), {})
 pydot.Node = type("Node", (), {})

--- a/tests/test_fas_bootstrap_threshold.py
+++ b/tests/test_fas_bootstrap_threshold.py
@@ -51,7 +51,14 @@ class _DummyGraph:
 
 causallearn_graph_GeneralGraph.GeneralGraph = _DummyGraph
 causallearn_graph_Edge.Edge = type("Edge", (), {})
-causallearn_graph_Endpoint.Endpoint = type("Endpoint", (), {})
+class _Endpoint(dict):
+    def __getattr__(self, name):
+        return self[name]
+
+
+causallearn_graph_Endpoint.Endpoint = _Endpoint(
+    TAIL="TAIL", ARROW="ARROW", CIRCLE="CIRCLE"
+)
 
 
 class GraphNode:

--- a/tests/test_pysr_structural_equations.py
+++ b/tests/test_pysr_structural_equations.py
@@ -1,0 +1,257 @@
+import numpy as np
+import pandas as pd
+import os
+import sys
+import types
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(ROOT)
+
+
+class Endpoint:
+    TAIL = "TAIL"
+    ARROW = "ARROW"
+    CIRCLE = "CIRCLE"
+
+
+class Edge:
+    def __init__(self, node1, node2, endpoint1=Endpoint.CIRCLE, endpoint2=Endpoint.CIRCLE):
+        self.node1, self.node2 = node1, node2
+        self.endpoint1, self.endpoint2 = endpoint1, endpoint2
+
+
+class Node:
+    def __init__(self, name):
+        self._name = name
+
+    def get_name(self):
+        return self._name
+
+
+class Graph:
+    def __init__(self, nodes):
+        self.nodes = nodes
+        self.node_map = {n: i for i, n in enumerate(nodes)}
+        self._edges = []
+
+    def add_edge(self, edge):
+        self._edges.append(edge)
+
+    def get_node_edges(self, node):
+        return [e for e in self._edges if e.node1 == node or e.node2 == node]
+
+    def get_children(self, node):
+        children = []
+        for e in self._edges:
+            if e.node1 == node and e.endpoint1 == Endpoint.TAIL and e.endpoint2 == Endpoint.ARROW:
+                children.append(e.node2)
+            elif e.node2 == node and e.endpoint2 == Endpoint.TAIL and e.endpoint1 == Endpoint.ARROW:
+                children.append(e.node1)
+        return children
+
+    def get_parents(self, node):
+        parents = []
+        for e in self._edges:
+            if e.node1 == node and e.endpoint1 == Endpoint.ARROW and e.endpoint2 == Endpoint.TAIL:
+                parents.append(e.node2)
+            elif e.node2 == node and e.endpoint2 == Endpoint.ARROW and e.endpoint1 == Endpoint.TAIL:
+                parents.append(e.node1)
+        return parents
+
+    def get_edge(self, n1, n2):
+        for e in self._edges:
+            if (e.node1 == n1 and e.node2 == n2) or (e.node1 == n2 and e.node2 == n1):
+                return e
+        return None
+
+    def is_directed_from_to(self, n1, n2):
+        e = self.get_edge(n1, n2)
+        if e is None:
+            return False
+        if e.node1 == n1 and e.endpoint1 == Endpoint.TAIL and e.endpoint2 == Endpoint.ARROW:
+            return True
+        if e.node2 == n1 and e.endpoint2 == Endpoint.TAIL and e.endpoint1 == Endpoint.ARROW:
+            return True
+        return False
+
+
+def _linear_fit(X, y, params):
+    if X.ndim == 1:
+        X = X.reshape(-1, 1)
+    if X.shape[1] == 0:
+        X = np.ones((len(X), 1))
+    X_ = np.c_[np.ones(len(X)), X]
+    coef, _, _, _ = np.linalg.lstsq(X_, y, rcond=None)
+    y_hat = X_ @ coef
+    r2 = 1 - np.sum((y - y_hat) ** 2) / np.sum((y - y.mean()) ** 2)
+    equation = " + ".join([f"{coef[i+1]:.3f}*x{i}" for i in range(len(coef) - 1)])
+    if equation:
+        equation = f"{coef[0]:.3f} + {equation}"
+    else:
+        equation = f"{coef[0]:.3f}"
+    return equation, float(r2)
+
+
+def _load_pysr_module(monkeypatch):
+    # Stub external dependencies required during import
+    bcsl = types.ModuleType("bcsl")
+    bcsl_fci = types.ModuleType("bcsl.fci")
+    bcsl_fci.fci_orient_edges_from_graph_node_sepsets = lambda *a, **k: None
+    bcsl_graph_utils = types.ModuleType("bcsl.graph_utils")
+    bcsl_graph_utils.get_bidirected_edge = lambda *a, **k: None
+    bcsl_graph_utils.get_directed_edge = lambda *a, **k: None
+    bcsl_graph_utils.get_nondirected_edge = lambda *a, **k: None
+    bcsl_graph_utils.get_undirected_edge = lambda *a, **k: None
+    bcsl_graph_utils.get_undirected_graph_from_skeleton = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "bcsl", bcsl)
+    monkeypatch.setitem(sys.modules, "bcsl.fci", bcsl_fci)
+    monkeypatch.setitem(sys.modules, "bcsl.graph_utils", bcsl_graph_utils)
+
+    pydot = types.ModuleType("pydot")
+    class _StubDot:
+        def __init__(self, *a, **k):
+            pass
+    pydot.Dot = _StubDot
+    monkeypatch.setitem(sys.modules, "pydot", pydot)
+
+    causallearn = types.ModuleType("causallearn")
+    causallearn_graph = types.ModuleType("causallearn.graph")
+    causallearn_graph_GeneralGraph = types.ModuleType("causallearn.graph.GeneralGraph")
+    causallearn_graph_Edge = types.ModuleType("causallearn.graph.Edge")
+    causallearn_graph_Endpoint = types.ModuleType("causallearn.graph.Endpoint")
+    causallearn_graph_GraphNode = types.ModuleType("causallearn.graph.GraphNode")
+    causallearn_graph_NodeType = types.ModuleType("causallearn.graph.NodeType")
+    class _StubGraph:
+        pass
+    class _StubEdge:
+        pass
+    class _StubEndpoint:
+        TAIL = "TAIL"
+        ARROW = "ARROW"
+        CIRCLE = "CIRCLE"
+    class _StubGraphNode:
+        def __init__(self, name):
+            self._name = name
+        def get_name(self):
+            return self._name
+    class _StubNodeType:
+        def __init__(self, name):
+            self.name = name
+    causallearn_graph_GeneralGraph.GeneralGraph = _StubGraph
+    causallearn_graph_Edge.Edge = _StubEdge
+    causallearn_graph_Endpoint.Endpoint = _StubEndpoint
+    causallearn_graph_GraphNode.GraphNode = _StubGraphNode
+    causallearn_graph_NodeType.NodeType = _StubNodeType
+    monkeypatch.setitem(sys.modules, "causallearn", causallearn)
+    monkeypatch.setitem(sys.modules, "causallearn.graph", causallearn_graph)
+    monkeypatch.setitem(sys.modules, "causallearn.graph.GeneralGraph", causallearn_graph_GeneralGraph)
+    monkeypatch.setitem(sys.modules, "causallearn.graph.Edge", causallearn_graph_Edge)
+    monkeypatch.setitem(sys.modules, "causallearn.graph.Endpoint", causallearn_graph_Endpoint)
+    monkeypatch.setitem(sys.modules, "causallearn.graph.GraphNode", causallearn_graph_GraphNode)
+    monkeypatch.setitem(sys.modules, "causallearn.graph.NodeType", causallearn_graph_NodeType)
+
+    causallearn_utils = types.ModuleType("causallearn.utils")
+    causallearn_utils_KCI = types.ModuleType("causallearn.utils.KCI")
+    causallearn_utils_KCI_KCI = types.ModuleType("causallearn.utils.KCI.KCI")
+    causallearn_utils_cit = types.ModuleType("causallearn.utils.cit")
+    causallearn_utils_KCI_KCI.KCI_UInd = lambda *a, **k: None
+    causallearn_utils_KCI_KCI.KCI_CInd = lambda *a, **k: None
+    causallearn_utils_cit.CIT = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "causallearn.utils", causallearn_utils)
+    monkeypatch.setitem(sys.modules, "causallearn.utils.KCI", causallearn_utils_KCI)
+    monkeypatch.setitem(sys.modules, "causallearn.utils.KCI.KCI", causallearn_utils_KCI_KCI)
+    monkeypatch.setitem(sys.modules, "causallearn.utils.cit", causallearn_utils_cit)
+
+    npeet_plus = types.ModuleType("npeet_plus")
+    npeet_plus.mi_pvalue = lambda *a, **k: (0, 0)
+    npeet_plus.mi = lambda *a, **k: 0
+    monkeypatch.setitem(sys.modules, "npeet_plus", npeet_plus)
+
+    scipy = types.ModuleType("scipy")
+    scipy_stats = types.ModuleType("scipy.stats")
+    scipy_stats.spearmanr = lambda *a, **k: (0, 0)
+    scipy_stats.pearsonr = lambda *a, **k: (0, 0)
+    monkeypatch.setitem(sys.modules, "scipy", scipy)
+    monkeypatch.setitem(sys.modules, "scipy.stats", scipy_stats)
+
+    sklearn = types.ModuleType("sklearn")
+    sklearn.__path__ = []
+    sklearn_cov = types.ModuleType("sklearn.covariance")
+    sklearn_feature = types.ModuleType("sklearn.feature_selection")
+    class GraphicalLassoCV:
+        def __init__(self, *a, **k):
+            pass
+        def fit(self, X):
+            self.precision_ = np.eye(X.shape[1])
+    sklearn_cov.GraphicalLassoCV = GraphicalLassoCV
+    sklearn_feature.mutual_info_regression = lambda *a, **k: np.zeros(a[0].shape[1])
+    monkeypatch.setitem(sys.modules, "sklearn", sklearn)
+    monkeypatch.setitem(sys.modules, "sklearn.covariance", sklearn_cov)
+    monkeypatch.setitem(sys.modules, "sklearn.feature_selection", sklearn_feature)
+
+    tqdm_module = types.ModuleType("tqdm")
+    tqdm_module.tqdm = lambda x, *a, **k: x
+    monkeypatch.setitem(sys.modules, "tqdm", tqdm_module)
+
+    causal_pipe_pkg = types.ModuleType("causal_pipe")
+    causal_pipe_pkg.__path__ = [os.path.join(ROOT, "causal_pipe")]
+    monkeypatch.setitem(sys.modules, "causal_pipe", causal_pipe_pkg)
+
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "causal_pipe.pysr_regression", os.path.join(ROOT, "causal_pipe", "pysr_regression.py")
+    )
+    pysr_reg = importlib.util.module_from_spec(spec)
+    sys.modules["causal_pipe.pysr_regression"] = pysr_reg
+    spec.loader.exec_module(pysr_reg)
+
+    monkeypatch.setattr(pysr_reg, "_fit_pysr", _linear_fit)
+    return pysr_reg
+
+
+def test_structural_equations_orientation(monkeypatch):
+    pysr_reg = _load_pysr_module(monkeypatch)
+    monkeypatch.setattr(
+        pysr_reg,
+        "search_best_graph_climber",
+        lambda *a, **k: (a[1], {}),
+    )
+
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=100)
+    y = 2 * x + rng.normal(scale=0.1, size=100)
+    df = pd.DataFrame({"A": x, "B": y})
+
+    node_a, node_b = Node("A"), Node("B")
+    g = Graph([node_a, node_b])
+    g.add_edge(Edge(node_a, node_b))
+
+    res = pysr_reg.symbolic_regression_causal_effect(df, g)
+
+    edge_info = next(iter(res["edge_tests"].values()))
+    orientation = edge_info["suggested_orientation"]
+    src, dst = orientation.split(" -> ")
+    models = res["structural_equations"]
+    assert src in models[dst]["parents"]
+    assert src in ["A", "B"] and dst in ["A", "B"]
+
+
+def test_no_hc_treats_undirected_as_parents(monkeypatch):
+    pysr_reg = _load_pysr_module(monkeypatch)
+
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=100)
+    y = 2 * x + rng.normal(scale=0.1, size=100)
+    df = pd.DataFrame({"A": x, "B": y})
+
+    node_a, node_b = Node("A"), Node("B")
+    g = Graph([node_a, node_b])
+    g.add_edge(Edge(node_a, node_b))
+
+    res = pysr_reg.symbolic_regression_causal_effect(
+        df, g, hc_orient_undirected_edges=False
+    )
+
+    assert res["edge_tests"] == {}
+    assert res["structural_equations"]["A"]["parents"] == ["B"]
+    assert res["structural_equations"]["B"]["parents"] == ["A"]

--- a/tests/test_respect_pag.py
+++ b/tests/test_respect_pag.py
@@ -9,6 +9,140 @@ causal_pipe_pkg.__path__ = [os.path.join(ROOT, "causal_pipe")]
 sys.modules.setdefault("causal_pipe", causal_pipe_pkg)
 
 import pytest
+import types
+
+# Stub out heavy dependencies from causallearn and bcsl.graph_utils
+causallearn = types.ModuleType("causallearn")
+causallearn_graph = types.ModuleType("causallearn.graph")
+causallearn_graph_GraphNode = types.ModuleType("causallearn.graph.GraphNode")
+causallearn_graph_GeneralGraph = types.ModuleType("causallearn.graph.GeneralGraph")
+causallearn_graph_Edge = types.ModuleType("causallearn.graph.Edge")
+causallearn_graph_Endpoint = types.ModuleType("causallearn.graph.Endpoint")
+
+
+class GraphNode:
+    def __init__(self, name):
+        self._name = name
+
+    def get_name(self):
+        return self._name
+
+
+class Edge:
+    def __init__(self, n1, n2, e1=None, e2=None):
+        self.node1, self.node2 = n1, n2
+        self.endpoint1, self.endpoint2 = e1, e2
+
+
+class Endpoint(dict):
+    def __getattr__(self, name):
+        return self[name]
+
+
+Endpoint = Endpoint(TAIL="TAIL", ARROW="ARROW", CIRCLE="CIRCLE")
+
+
+class GeneralGraph:
+    def __init__(self, nodes):
+        self._nodes = nodes
+        self._edges = []
+        self.node_map = {node: i for i, node in enumerate(nodes)}
+
+    def add_edge(self, edge):
+        if edge is not None:
+            self._edges.append(edge)
+
+    def add_directed_edge(self, n1, n2):
+        self.add_edge(Edge(n1, n2, Endpoint.TAIL, Endpoint.ARROW))
+
+    def remove_edge(self, edge):
+        if edge in self._edges:
+            self._edges.remove(edge)
+
+    def remove_connecting_edge(self, n1, n2):
+        edge = self.get_edge(n1, n2)
+        if edge in self._edges:
+            self._edges.remove(edge)
+
+    def get_graph_edges(self):
+        return self._edges
+
+    def get_nodes(self):
+        return self._nodes
+
+    def get_num_nodes(self):
+        return len(self._nodes)
+
+    def get_edge(self, n1, n2):
+        for e in self._edges:
+            if e is None:
+                continue
+            if (e.node1 == n1 and e.node2 == n2) or (e.node1 == n2 and e.node2 == n1):
+                return e
+        return None
+
+    def get_node_edges(self, node):
+        return [e for e in self._edges if e.node1 == node or e.node2 == node]
+
+    def is_adjacent_to(self, n1, n2):
+        return self.get_edge(n1, n2) is not None
+
+    def is_directed_from_to(self, n1, n2):
+        e = self.get_edge(n1, n2)
+        if e is None:
+            return False
+        if e.node1 == n1 and e.endpoint1 == Endpoint.TAIL and e.endpoint2 == Endpoint.ARROW:
+            return True
+        if e.node2 == n1 and e.endpoint2 == Endpoint.TAIL and e.endpoint1 == Endpoint.ARROW:
+            return True
+        return False
+
+    def get_children(self, node):
+        children = []
+        for e in self._edges:
+            if e.node1 == node and e.endpoint1 == Endpoint.TAIL and e.endpoint2 == Endpoint.ARROW:
+                children.append(e.node2)
+            elif e.node2 == node and e.endpoint2 == Endpoint.TAIL and e.endpoint1 == Endpoint.ARROW:
+                children.append(e.node1)
+        return children
+
+    def get_parents(self, node):
+        parents = []
+        for e in self._edges:
+            if e.node1 == node and e.endpoint1 == Endpoint.ARROW and e.endpoint2 == Endpoint.TAIL:
+                parents.append(e.node2)
+            elif e.node2 == node and e.endpoint2 == Endpoint.ARROW and e.endpoint1 == Endpoint.TAIL:
+                parents.append(e.node1)
+        return parents
+
+
+causallearn_graph_GraphNode.GraphNode = GraphNode
+causallearn_graph_GeneralGraph.GeneralGraph = GeneralGraph
+causallearn_graph_Edge.Edge = Edge
+causallearn_graph_Endpoint.Endpoint = Endpoint
+
+sys.modules.setdefault("causallearn", causallearn)
+sys.modules.setdefault("causallearn.graph", causallearn_graph)
+sys.modules.setdefault("causallearn.graph.GraphNode", causallearn_graph_GraphNode)
+sys.modules.setdefault("causallearn.graph.GeneralGraph", causallearn_graph_GeneralGraph)
+sys.modules.setdefault("causallearn.graph.Edge", causallearn_graph_Edge)
+sys.modules.setdefault("causallearn.graph.Endpoint", causallearn_graph_Endpoint)
+
+bcsl_graph_utils = types.ModuleType("bcsl.graph_utils")
+
+
+def get_bidirected_edge(n1, n2):
+    return Edge(n1, n2, Endpoint.ARROW, Endpoint.ARROW)
+
+
+def get_directed_edge(n1, n2):
+    return Edge(n1, n2, Endpoint.TAIL, Endpoint.ARROW)
+
+
+bcsl_graph_utils.get_bidirected_edge = get_bidirected_edge
+bcsl_graph_utils.get_directed_edge = get_directed_edge
+sys.modules.setdefault("bcsl.graph_utils", bcsl_graph_utils)
+
 from causallearn.graph.GraphNode import GraphNode
 from causallearn.graph.GeneralGraph import GeneralGraph
 from causallearn.graph.Edge import Edge


### PR DESCRIPTION
## Summary
- support optional hill-climb orientation of undirected edges before PySR structural equation fitting
- allow disabling orientation to treat undirected neighbors as parents
- document PySR's `hc_orient_undirected_edges` parameter and cover both modes with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68be24cc8e988330a1669699f36054bc