### PR TITLE
feat: visualize PySR equations at nodes

### DIFF
--- a/causal_pipe/causal_discovery/static_causal_discovery.py
+++ b/causal_pipe/causal_discovery/static_causal_discovery.py
@@ -24,6 +24,7 @@ from scipy import stats
 from statsmodels.stats.outliers_influence import variance_inflation_factor
 
 from causal_pipe.utilities.graph_utilities import graph_with_coefficient_to_pydot
+from typing import Optional, Dict
 
 
 def mi_to_pearson(mi):
@@ -526,7 +527,13 @@ def visualize_causal_graph(
 
 
 def visualize_graph(
-    graph, edges=None, title=None, show=True, output_path=None, labels=None
+    graph,
+    edges=None,
+    title=None,
+    show=True,
+    output_path=None,
+    labels=None,
+    structural_equations: Optional[Dict[str, str]] = None,
 ):
     """
     Visualizes the causal graph.
@@ -536,9 +543,17 @@ def visualize_graph(
     - title (str): The title of the graph.
     - show (bool): Whether to display the graph.
     - output_path (str): The path to save the graph image.
-    - labels (list): Optional list of labels for the nodes
+    - labels (list): Optional list of labels for the nodes.
+    - structural_equations (dict): Optional mapping of node names to structural
+      equation strings. When provided, equations are displayed under nodes.
     """
-    pyd = graph_with_coefficient_to_pydot(graph, edges=edges, labels=labels, dpi=300)
+    pyd = graph_with_coefficient_to_pydot(
+        graph,
+        edges=edges,
+        labels=labels,
+        dpi=300,
+        structural_equations=structural_equations,
+    )
     tmp_png = pyd.create_png()
     sio = io.BytesIO()
     sio.write(tmp_png)

--- a/causal_pipe/causal_pipe.py
+++ b/causal_pipe/causal_pipe.py
@@ -762,17 +762,20 @@ class CausalPipe:
                     #     show=show_plot,
                     #     output_path=os.path.join(out_dir, "pysr_scm.png"),
                     # )
-                    coef_graph, edges_with_coefficients = (
+                    coef_graph, edges, structural_equations = (
                         add_psyr_structural_equation_to_edge_coefficients(
                             psyr_output=self.causal_effects[method.name],
                         )
                     )
                     visualize_graph(
                         coef_graph,
-                        edges=edges_with_coefficients,
+                        edges=edges,
+                        structural_equations=structural_equations,
                         title="PySR SCM Result",
                         show=show_plot,
-                        output_path=os.path.join(out_dir, "pysr_scm_with_equations.png")
+                        output_path=os.path.join(
+                            out_dir, "pysr_scm_with_equations.png"
+                        ),
                     )
             else:
                     raise ValueError(

--- a/causal_pipe/utilities/graph_utilities.py
+++ b/causal_pipe/utilities/graph_utilities.py
@@ -5,6 +5,7 @@ from typing import List, Tuple, Dict, Any, Optional
 
 import numpy as np
 import pydot
+import html
 from bcsl.graph_utils import (
     get_nondirected_edge,
     get_undirected_edge,
@@ -798,8 +799,21 @@ def add_edge_coefficients_from_sem_fit(
 
 def add_psyr_structural_equation_to_edge_coefficients(
     psyr_output: Dict[str, Any],
-) -> Tuple[GeneralGraph, List[Edge]]:
-    """Extract coefficients from PySR structural equations."""
+) -> Tuple[GeneralGraph, List[Edge], Dict[str, str]]:
+    """
+    Extract structural equations from PySR output.
+
+    Parameters
+    ----------
+    psyr_output : Dict[str, Any]
+        Output dictionary returned by ``symbolic_regression_causal_effect``.
+
+    Returns
+    -------
+    Tuple[GeneralGraph, List[Edge], Dict[str, str]]
+        A copy of the final graph, its edges and a mapping from node name to
+        its structural equation string.
+    """
     final_graph = psyr_output.get("final_graph")
     if final_graph is None:
         raise ValueError("No final_graph in psyr_output.")
@@ -808,26 +822,14 @@ def add_psyr_structural_equation_to_edge_coefficients(
         raise ValueError("No structural_equations in psyr_output.")
 
     coef_graph = copy_graph(final_graph)
-    edges_with_coefficients: List[Edge] = []
-    added_equation_to_node = {}
-    for edge in final_graph.get_graph_edges():
-        n1 = edge.get_node1()
-        n2 = edge.get_node2()
-        endpoint_1 = edge.endpoint1
-        endpoint_2 = edge.endpoint2
-        equation = structural_equations.get(n2.get_name()).get("equation")
-        if equation is None or n2.get_name() in added_equation_to_node:
-            edges_with_coefficients.append(edge)
-            continue
-        added_equation_to_node[n2.get_name()] = True
-        edge_coef = EdgeWithCoefficient(
-            n1, n2, endpoint_1, endpoint_2, coefficient=equation
-        )
-        coef_graph.remove_edge(edge)
-        coef_graph.add_edge(edge_coef)
-        edges_with_coefficients.append(edge_coef)
+    edges: List[Edge] = coef_graph.get_graph_edges()
+    node_equations: Dict[str, str] = {}
+    for node_name, info in structural_equations.items():
+        equation = info.get("equation")
+        if equation is not None:
+            node_equations[node_name] = equation
 
-    return coef_graph, edges_with_coefficients
+    return coef_graph, edges, node_equations
 
 
 class EdgeWithCoefficient(Edge):
@@ -918,6 +920,7 @@ def graph_with_coefficient_to_pydot(
     labels: Optional[List[str]] = None,
     title: str = "",
     dpi: float = 200,
+    structural_equations: Optional[Dict[str, str]] = None,
 ) -> pydot.Dot:
     """
     Convert a GeneralGraph object to a DOT object with edge coefficients and color coding.
@@ -934,13 +937,15 @@ def graph_with_coefficient_to_pydot(
         The title of the graph.
     dpi : float, optional (default=200)
         The resolution of the graph.
+    structural_equations : dict, optional (default=None)
+        Mapping from node name to structural equation string. If provided, the
+        equation is displayed under the node label.
 
     Returns
     -------
     pydot_g : pydot.Dot
         The DOT representation of the graph.
     """
-    import pydot
 
     nodes = G.get_nodes()
     if labels is not None:
@@ -952,7 +957,12 @@ def graph_with_coefficient_to_pydot(
 
     # Add nodes to the pydot graph
     for i, node in enumerate(nodes):
-        node_label = labels[i] if labels is not None else node.get_name()
+        node_name = node.get_name()
+        node_label = labels[i] if labels is not None else node_name
+        if structural_equations and node_name in structural_equations:
+            equation = html.escape(str(structural_equations[node_name]))
+            base_label = html.escape(str(node_label))
+            node_label = f"<{base_label}<br/><font point-size='8'>{equation}</font>>"
         node_shape = "square" if node.get_node_type() == NodeType.LATENT else "ellipse"
         pydot_node = pydot.Node(str(i), label=node_label, shape=node_shape)
         pydot_g.add_node(pydot_node)


### PR DESCRIPTION
## Summary
- add support to pass PySR structural equations and render them beneath nodes
- expose `structural_equations` parameter in `visualize_graph`
- show PySR structural equations alongside graphs produced in the pipeline

## Testing
- `pytest` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_b_68c004e1365083309a34958667111375